### PR TITLE
Add to cart button disabled if out of stock

### DIFF
--- a/pages/product/_slug.vue
+++ b/pages/product/_slug.vue
@@ -39,7 +39,7 @@
           <AttributeSelections class="my-4" v-if="product.type == 'VARIABLE' && product.attributes" :attrs="product.attributes.nodes.filter(attr => attr.variation != false)" @attrs-changed="updateSelectedVariations" />
           <div class="flex mt-8 gap-4 items-center">
             <QuantityButtons class="w-28" @quantity-change="updateQuantity" :quantity="quantity" :min="1" />
-            <AddToCartButton class="flex-1 w-full md:max-w-xs" :add-to-cart-button-text="addToCartButtonText" :disabled="!activeVariation && product.variations" :class="{
+            <AddToCartButton class="flex-1 w-full md:max-w-xs" :add-to-cart-button-text="addToCartButtonText" :disabled="!activeVariation && product.variations || activeVariation.stockStatus == `OUT_OF_STOCK`" :class="{
               loading: addToCartState == 'loading',
               success: addToCartState == 'success',
             }" />


### PR DESCRIPTION
An error is encountered when the inventory variants are added to the cart. The add to cart button is disabled if out of stock.

![image](https://user-images.githubusercontent.com/79358543/204568227-80870cdf-8943-4fd0-92d2-2c44a9e2c97c.png)
![image](https://user-images.githubusercontent.com/79358543/204568336-602f3e1e-db80-4295-a430-ebad01221911.png)
