### PR TITLE
The second demo address has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Next Generation Front-End for WooCommerce
 
 * [Live Demo](https://demo.woonuxt.com/) ⚡️
-* [Second Demo](https://woonuxt-zackha.netlify.app/) ⚡️ ([Fork](https://github.com/zackha/woonuxt) by [@zackha](https://github.com/zackha))
+* [Second Demo](https://demo2-woonuxt.netlify.app/) ⚡️ ([Fork](https://github.com/zackha/woonuxt) by [@zackha](https://github.com/zackha))
 
 ### Required WordPress Plugins
 * [WPGraphQL](https://www.wpgraphql.com)


### PR DESCRIPTION
The second demo site address has changed to [demo2-woonuxt.netlify.app](https://demo2-woonuxt.netlify.app/)