### PR TITLE
Fix: sale badge calculation for variable products

### DIFF
--- a/pages/product/[slug].vue
+++ b/pages/product/[slug].vue
@@ -19,7 +19,7 @@
         :first-image="product.image.sourceUrl"
         :main-image="type.image.sourceUrl"
         :gallery="product.galleryImages"
-        :node="product"
+        :node="type"
       />
 
       <div class="md:max-w-md md:py-2">


### PR DESCRIPTION
The value of the sale badge is currently calculated based on the `product` object. This works for simple products, but variable products are calculated wrong.

I changed the node-prop for the ProductImageGallery-Component to `type`, so everything is calculated correctly.