### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/woonuxt_base/components/shopElements/ProductSearch.vue
+++ b/woonuxt_base/components/shopElements/ProductSearch.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { onBeforeRouteUpdate } from 'nuxt/app';
+import { onBeforeRouteUpdate } from '#imports';
 const { getSearchQuery, setSearchQuery, clearSearchQuery, searchProducts, isSearchActive } = useSearching();
 const searchQuery = ref(getSearchQuery());
 


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.