### PR TITLE
Make pathPrefix false for subComponents

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,11 @@
+import { createResolver } from '@nuxt/kit';
+const { resolve } = createResolver(import.meta.url);
+
 export default defineNuxtConfig({
   // Get all the pages, components, composables and plugins from the parent theme
   extends: ['./woonuxt_base'],
+
+  components: [{ path: resolve('./components'), pathPrefix: false }],
 
   /**
    * Depending on your servers capabilities, you may need to adjust the following settings.


### PR DESCRIPTION
In order to be able to override MyHeader which is inside generalElements the `pathPrefix: false` is needed in the root` nuxt-config.ts`