### PR TITLE
Remove optional text from zip text input

### DIFF
--- a/woonuxt_base/components/forms/BillingDetails.vue
+++ b/woonuxt_base/components/forms/BillingDetails.vue
@@ -47,7 +47,7 @@ const billing = toRef(props, 'modelValue');
     </div>
 
     <div class="w-full">
-      <label for="zip">ZIP ({{ $t('messages.general.optional') }})</label>
+      <label for="zip">ZIP</label>
       <input v-model="billing.postcode" placeholder="D01 1234" type="text" required />
     </div>
 


### PR DESCRIPTION
Zip should be required. So the optional text should not be there.
Making a PR to fix this