### PR TITLE
Fix: show sale price as html

### DIFF
--- a/woonuxt_base/components/productElements/ProductPrice.vue
+++ b/woonuxt_base/components/productElements/ProductPrice.vue
@@ -10,6 +10,6 @@ const { regularPrice, salePrice } = defineProps<ProductPriceProps>();
 <template>
   <div v-if="regularPrice" class="flex font-semibold">
     <span :class="{ 'text-gray-400 line-through font-normal': salePrice }" v-html="regularPrice" />
-    <span v-if="salePrice" class="ml-2">{{ salePrice }}</span>
+    <span v-if="salePrice" class="ml-2" v-html="salePrice" />
   </div>
 </template>


### PR DESCRIPTION
The product sale price is displayed with `&nbsp;` rendered as a string:
![image](https://github.com/scottyzen/woonuxt/assets/1384378/0c1475cb-9ebc-477e-8617-721ec142fa36)
With this fix, it should be rendered as HTML:
![image](https://github.com/scottyzen/woonuxt/assets/1384378/f176e703-bf1e-452f-b5bd-f8987651765a)
It's an addition to pull request #19