### PR TITLE
Enhancement/local ssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ logs
 
 # Local Netlify folder
 .netlify
+
+*.pem

--- a/README.md
+++ b/README.md
@@ -115,6 +115,18 @@ Example: I have created a pages directory and added a `contact.vue` file in the 
 | Italian 🇮🇹    | it   |
 | Portuguese 🇵🇹 | pt   |
 
+### Local SSL Setup
+
+- Install [mkcert](https://github.com/FiloSottile/mkcert) on your machine.
+- Run `mkcert localhost` to generate a certificate for localhost.
+- Then run `mkcert -install` to install the certificate authority.
+- Append ssl when running the dev server, example:
+
+```bash
+# Run the dev server with SSL
+npm run dev:ssl
+```
+
 #### Credits
 
 This is an ongoing project but it wouldn't be possible without the help of the following people: [Jason Bahl](https://github.com/jasonbahl) & [Geoffrey K Taylor](https://github.com/kidunot89) for their ongoing work on WPGraphQL and WooGraphQL respectively. Also, a big thanks to the Nuxt team for all their hard work making Nuxt 3 a pleasure to build upon. And the [WooCommerce](https://woocommerce.com/) team for making such a great e-commerce platform. Some other honorable mentions are [Funkhaus](https://funkhaus.us/) for their work on the WPGraphQL Cors plugin. And the people who have contributed to making WooNuxt better every day. [Zack Hatlen](https://github.com/zackha), [Galli](https://github.com/Zielgestalt), [Guillaume](https://github.com/GuillaumeDgr), Thank you all! 🙏

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "build": "nuxt build",
     "dev": "nuxt dev --host",
+    "dev:ssl": "NODE_TLS_REJECT_UNAUTHORIZED=0 nuxt dev --https --ssl-cert localhost.pem --ssl-key localhost-key.pem",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",

--- a/woonuxt_base/composables/useCart.ts
+++ b/woonuxt_base/composables/useCart.ts
@@ -27,9 +27,8 @@ export function useCart() {
       return { cart, customer, viewer, paymentGateways };
     } catch (error: any) {
       logGQLError(error);
+      return { cart: null, customer: null, viewer: null, paymentGateways: null };
     }
-
-    return null;
   }
 
   function updateCart(payload: Cart | null): void {
@@ -75,8 +74,8 @@ export function useCart() {
       return quantity;
     } catch (error: any) {
       logGQLError(error);
+      return undefined;
     }
-    return undefined;
   }
 
   // empty the cart

--- a/woonuxt_base/package.json
+++ b/woonuxt_base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woonuxt",
-  "version": "3.6.3",
+  "version": "3.6.4",
   "main": "./nuxt.config.ts",
   "type": "module"
 }


### PR DESCRIPTION
## Add SSL support for local development with a self-signed certificate

Self-signed certificate #124
- Add SSL support for local development.
- Update README.md to include instructions for setting it up. You can find the instructions [here](https://github.com/scottyzen/woonuxt?tab=readme-ov-file#local-ssl-setup).
- Tested this setup with [Local](https://localwp.com/) by Flywheel.