### PR TITLE
Add metadata query in getProduct

### DIFF
--- a/woonuxt_base/app/queries/getProduct.gql
+++ b/woonuxt_base/app/queries/getProduct.gql
@@ -4,6 +4,11 @@ query getProduct($slug: ID!) {
     type
     databaseId
     id
+    metaData {
+      id
+      key
+      value
+    }
     slug
     sku
     description


### PR DESCRIPTION
I would like to extend the getProduct.gql query to include additional metadata.
I have some extra data that I believe would enhance the product page and could be beneficial for others as well.