### PR TITLE
Add Downloads List

### DIFF
--- a/woonuxt_base/app/components/DownloadList.vue
+++ b/woonuxt_base/app/components/DownloadList.vue
@@ -1,4 +1,4 @@
-<script setup>
+<script setup lang="ts">
 const router = useRouter();
 const { formatDate, scrollToTop } = useHelpers();
 const { getOrders, downloadableOrders } = useAuth();
@@ -18,7 +18,7 @@ const refresh = () => {
   getOrders();
 };
 
-const downloadFile = (downloadUrl) => {
+const downloadFile = (downloadUrl: string) => {
   window.open(downloadUrl, '_blank');
 };
 </script>

--- a/woonuxt_base/app/components/DownloadList.vue
+++ b/woonuxt_base/app/components/DownloadList.vue
@@ -1,13 +1,9 @@
 <script setup lang="ts">
 const router = useRouter();
-const { formatDate, scrollToTop } = useHelpers();
+const { scrollToTop } = useHelpers();
 const { getDownloads, downloads } = useAuth();
 
 if (downloads.value === null) getDownloads();
-
-const allDownloadableItems = computed(() => {
-  return downloads.value?.downloadableItems?.nodes;
-});
 
 const refresh = () => {
   downloads.value = null;
@@ -15,38 +11,12 @@ const refresh = () => {
   getDownloads();
 };
 
-const downloadFile = (downloadUrl: string) => {
-  window.open(downloadUrl, '_blank');
-};
 </script>
 
 <template>
   <div class="bg-white rounded-lg flex shadow min-h-[250px] p-12 justify-center items-center">
-    <div v-if="allDownloadableItems && allDownloadableItems.length" class="w-full">
-      <table class="w-full text-left table-auto" aria-label="Download List">
-        <thead>
-          <tr>
-            <th>{{ $t('messages.general.product') }}</th>
-            <th>{{ $t('messages.shop.downloadsRemaining') }}</th>
-            <th>{{ $t('messages.shop.expires') }}</th>
-            <th class="text-right">{{ $t('messages.general.download') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="download in allDownloadableItems" :key="download.id">
-            <td class="rounded-l-lg ">
-              <router-link :to="`/product/${download.product?.slug}`" class="cursor-pointer hover:underline">{{ download.product?.name }}</router-link>
-            </td>
-            <td>{{ download.downloadsRemaining ? download.downloadsRemaining : '∞' }}</td>
-            <td>{{ download.accessExpires ? formatDate(download.accessExpires) : 'Never' }}</td>
-            <td class="text-right rounded-r-lg" v-if="download.url">
-              <button @click.stop="downloadFile(download.url)" class="text-blue-500 hover:text-blue-700 hover:underline cursor-pointer ">
-                {{ download.name }}
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+    <div v-if="downloads && downloads.length" class="w-full">
+      <DownloadableItems :downloadableItems="downloads" />
       <div class="text-center flex justify-center w-full mt-8">
         <button type="button" @click="refresh" class="flex items-center gap-1 text-sm leading-none hover:bg-gray-50 p-2 rounded">
           <span>Refresh list</span>
@@ -54,22 +24,10 @@ const downloadFile = (downloadUrl: string) => {
         </button>
       </div>
     </div>
-    <div v-else-if="allDownloadableItems && allDownloadableItems.length === 0" class="min-h-[250px] flex items-center justify-center text-gray-500 text-lg">No downloads found.</div>
+    <div v-else-if="downloads && downloads.length === 0" class="min-h-[250px] flex items-center justify-center text-gray-500 text-lg">No downloads found.</div>
     <LoadingIcon v-else size="24" stroke="2" />
   </div>
 </template>
 
 <style lang="postcss" scoped>
-tbody tr:nth-child(odd) {
-  background-color: #fafafa;
-}
-
-tbody tr {
-  @apply text-sm text-gray-500;
-}
-
-td,
-th {
-  @apply py-2 px-3;
-}
 </style>

--- a/woonuxt_base/app/components/DownloadList.vue
+++ b/woonuxt_base/app/components/DownloadList.vue
@@ -1,0 +1,78 @@
+<script setup>
+const router = useRouter();
+const { formatDate, scrollToTop } = useHelpers();
+const { getOrders, downloadableOrders } = useAuth();
+
+if (downloadableOrders.value === null) getOrders();
+
+const allDownloadableItems = computed(() => {
+  if (downloadableOrders.value) {
+    return downloadableOrders.value.flatMap((order) => order.downloadableItems.nodes);
+  }
+  return [];
+});
+
+const refresh = () => {
+  downloadableOrders.value = null;
+  scrollToTop();
+  getOrders();
+};
+
+const downloadFile = (downloadUrl) => {
+  window.open(downloadUrl, '_blank');
+};
+</script>
+
+<template>
+  <div class="bg-white rounded-lg flex shadow min-h-[250px] p-12 justify-center items-center">
+    <div v-if="allDownloadableItems && allDownloadableItems.length" class="w-full">
+      <table class="w-full text-left table-auto" aria-label="Download List">
+        <thead>
+          <tr>
+            <th>{{ $t('messages.general.product') }}</th>
+            <th>{{ $t('messages.shop.downloadsRemaining') }}</th>
+            <th>{{ $t('messages.shop.expires') }}</th>
+            <th class="text-right">{{ $t('messages.general.download') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="download in allDownloadableItems" :key="download.id">
+            <td class="rounded-l-lg ">
+              <router-link :to="`/product/${download.product.slug}`" class="cursor-pointer hover:underline">{{ download.product.name }}</router-link>
+            </td>
+            <td>{{ download.downloadsRemaining ? download.downloadsRemaining : '∞' }}</td>
+            <td>{{ download.accessExpires ? formatDate(download.accessExpires) : 'Never' }}</td>
+            <td class="text-right rounded-r-lg">
+              <button @click.stop="downloadFile(download.url)" class="text-blue-500 hover:text-blue-700 hover:underline cursor-pointer ">
+                {{ download.name }}
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="text-center flex justify-center w-full mt-8">
+        <button type="button" @click="refresh" class="flex items-center gap-1 text-sm leading-none hover:bg-gray-50 p-2 rounded">
+          <span>Refresh list</span>
+          <Icon name="ion:refresh-outline" />
+        </button>
+      </div>
+    </div>
+    <div v-else-if="downloadableOrders && downloadableOrders.length === 0" class="min-h-[250px] flex items-center justify-center text-gray-500 text-lg">No downloads found.</div>
+    <LoadingIcon v-else size="24" stroke="2" />
+  </div>
+</template>
+
+<style lang="postcss" scoped>
+tbody tr:nth-child(odd) {
+  background-color: #fafafa;
+}
+
+tbody tr {
+  @apply text-sm text-gray-500 hover:text-gray-800;
+}
+
+td,
+th {
+  @apply py-2 px-3;
+}
+</style>

--- a/woonuxt_base/app/components/DownloadList.vue
+++ b/woonuxt_base/app/components/DownloadList.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-const router = useRouter();
 const { scrollToTop } = useHelpers();
 const { getDownloads, downloads } = useAuth();
 
@@ -10,7 +9,6 @@ const refresh = () => {
   scrollToTop();
   getDownloads();
 };
-
 </script>
 
 <template>
@@ -28,6 +26,3 @@ const refresh = () => {
     <LoadingIcon v-else size="24" stroke="2" />
   </div>
 </template>
-
-<style lang="postcss" scoped>
-</style>

--- a/woonuxt_base/app/components/DownloadList.vue
+++ b/woonuxt_base/app/components/DownloadList.vue
@@ -1,21 +1,18 @@
 <script setup lang="ts">
 const router = useRouter();
 const { formatDate, scrollToTop } = useHelpers();
-const { getOrders, downloadableOrders } = useAuth();
+const { getDownloads, downloads } = useAuth();
 
-if (downloadableOrders.value === null) getOrders();
+if (downloads.value === null) getDownloads();
 
 const allDownloadableItems = computed(() => {
-  if (downloadableOrders.value) {
-    return downloadableOrders.value.flatMap((order) => order.downloadableItems.nodes);
-  }
-  return [];
+  return downloads.value?.downloadableItems?.nodes;
 });
 
 const refresh = () => {
-  downloadableOrders.value = null;
+  downloads.value = null;
   scrollToTop();
-  getOrders();
+  getDownloads();
 };
 
 const downloadFile = (downloadUrl: string) => {
@@ -38,11 +35,11 @@ const downloadFile = (downloadUrl: string) => {
         <tbody>
           <tr v-for="download in allDownloadableItems" :key="download.id">
             <td class="rounded-l-lg ">
-              <router-link :to="`/product/${download.product.slug}`" class="cursor-pointer hover:underline">{{ download.product.name }}</router-link>
+              <router-link :to="`/product/${download.product?.slug}`" class="cursor-pointer hover:underline">{{ download.product?.name }}</router-link>
             </td>
             <td>{{ download.downloadsRemaining ? download.downloadsRemaining : '∞' }}</td>
             <td>{{ download.accessExpires ? formatDate(download.accessExpires) : 'Never' }}</td>
-            <td class="text-right rounded-r-lg">
+            <td class="text-right rounded-r-lg" v-if="download.url">
               <button @click.stop="downloadFile(download.url)" class="text-blue-500 hover:text-blue-700 hover:underline cursor-pointer ">
                 {{ download.name }}
               </button>
@@ -57,7 +54,7 @@ const downloadFile = (downloadUrl: string) => {
         </button>
       </div>
     </div>
-    <div v-else-if="downloadableOrders && downloadableOrders.length === 0" class="min-h-[250px] flex items-center justify-center text-gray-500 text-lg">No downloads found.</div>
+    <div v-else-if="allDownloadableItems && allDownloadableItems.length === 0" class="min-h-[250px] flex items-center justify-center text-gray-500 text-lg">No downloads found.</div>
     <LoadingIcon v-else size="24" stroke="2" />
   </div>
 </template>

--- a/woonuxt_base/app/components/DownloadList.vue
+++ b/woonuxt_base/app/components/DownloadList.vue
@@ -68,7 +68,7 @@ tbody tr:nth-child(odd) {
 }
 
 tbody tr {
-  @apply text-sm text-gray-500 hover:text-gray-800;
+  @apply text-sm text-gray-500;
 }
 
 td,

--- a/woonuxt_base/app/components/DownloadableItems.vue
+++ b/woonuxt_base/app/components/DownloadableItems.vue
@@ -2,9 +2,8 @@
 const { formatDate } = useHelpers();
 
 const props = defineProps({
-  downloadableItems: { type: Object as PropType<DownloadableItem[]>, required: true },
+  downloadableItems: { type: Object as PropType<DownloadableItem[]>, default: [] },
 });
-
 </script>
 
 <template>
@@ -14,18 +13,18 @@ const props = defineProps({
         <th>{{ $t('messages.general.product') }}</th>
         <th>{{ $t('messages.shop.downloadsRemaining') }}</th>
         <th>{{ $t('messages.shop.expires') }}</th>
-        <th class="text-right">{{ $t('messages.general.download') }}</th>
+        <th>{{ $t('messages.general.download') }}</th>
       </tr>
     </thead>
     <tbody>
-      <tr v-for="download in props.downloadableItems" :key="download.id">
+      <tr v-for="item in props.downloadableItems" :key="item.id">
         <td class="rounded-l-lg">
-          <router-link :to="`/product/${download.product?.slug}`" class="cursor-pointer hover:underline">{{ download.product?.name }}</router-link>
+          <NuxtLink :to="`/product/${item.product.slug}`" class="hover:underline">{{ item.product.name }}</NuxtLink>
         </td>
-        <td>{{ download.downloadsRemaining ? download.downloadsRemaining : '∞' }}</td>
-        <td>{{ download.accessExpires ? formatDate(download.accessExpires) : 'Never' }}</td>
-        <td class="text-right rounded-r-lg" v-if="download.url">
-          <a :href="download.url" :download="download.name" class="text-blue-500 hover:text-blue-700 hover:underline cursor-pointer">{{ download.name }}</a>
+        <td>{{ item.downloadsRemaining || '∞' }}</td>
+        <td>{{ item.accessExpires ? formatDate(item.accessExpires) : 'Never' }}</td>
+        <td v-if="item.url">
+          <a :href="item.url" :download="item.name" class="text-primary hover:text-primary-dark hover:underline">{{ item.name }}</a>
         </td>
       </tr>
     </tbody>

--- a/woonuxt_base/app/components/DownloadableItems.vue
+++ b/woonuxt_base/app/components/DownloadableItems.vue
@@ -5,9 +5,6 @@ const props = defineProps({
   downloadableItems: { type: Object as PropType<DownloadableItem[]>, required: true },
 });
 
-const downloadFile = (downloadUrl: string) => {
-  window.open(downloadUrl, '_blank');
-};
 </script>
 
 <template>

--- a/woonuxt_base/app/components/DownloadableItems.vue
+++ b/woonuxt_base/app/components/DownloadableItems.vue
@@ -28,9 +28,7 @@ const downloadFile = (downloadUrl: string) => {
         <td>{{ download.downloadsRemaining ? download.downloadsRemaining : '∞' }}</td>
         <td>{{ download.accessExpires ? formatDate(download.accessExpires) : 'Never' }}</td>
         <td class="text-right rounded-r-lg" v-if="download.url">
-          <button @click.stop="downloadFile(download.url)" class="text-blue-500 hover:text-blue-700 hover:underline cursor-pointer">
-            {{ download.name }}
-          </button>
+          <a :href="download.url" :download="download.name" class="text-blue-500 hover:text-blue-700 hover:underline cursor-pointer">{{ download.name }}</a>
         </td>
       </tr>
     </tbody>

--- a/woonuxt_base/app/components/DownloadableItems.vue
+++ b/woonuxt_base/app/components/DownloadableItems.vue
@@ -2,7 +2,7 @@
 const { formatDate } = useHelpers();
 
 const props = defineProps({
-  downloadableItems: { type: Object, required: true },
+  downloadableItems: { type: Object as PropType<DownloadableItem[]>, required: true },
 });
 
 const downloadFile = (downloadUrl: string) => {

--- a/woonuxt_base/app/components/DownloadableItems.vue
+++ b/woonuxt_base/app/components/DownloadableItems.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+const { formatDate } = useHelpers();
+
+const props = defineProps({
+  downloadableItems: { type: Object, required: true },
+});
+
+const downloadFile = (downloadUrl: string) => {
+  window.open(downloadUrl, '_blank');
+};
+</script>
+
+<template>
+  <table class="w-full text-left table-auto" aria-label="Download List">
+    <thead>
+      <tr>
+        <th>{{ $t('messages.general.product') }}</th>
+        <th>{{ $t('messages.shop.downloadsRemaining') }}</th>
+        <th>{{ $t('messages.shop.expires') }}</th>
+        <th class="text-right">{{ $t('messages.general.download') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="download in props.downloadableItems" :key="download.id">
+        <td class="rounded-l-lg">
+          <router-link :to="`/product/${download.product?.slug}`" class="cursor-pointer hover:underline">{{ download.product?.name }}</router-link>
+        </td>
+        <td>{{ download.downloadsRemaining ? download.downloadsRemaining : '∞' }}</td>
+        <td>{{ download.accessExpires ? formatDate(download.accessExpires) : 'Never' }}</td>
+        <td class="text-right rounded-r-lg" v-if="download.url">
+          <button @click.stop="downloadFile(download.url)" class="text-blue-500 hover:text-blue-700 hover:underline cursor-pointer">
+            {{ download.name }}
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<style lang="postcss" scoped>
+tbody tr:nth-child(odd) {
+  background-color: #fafafa;
+}
+
+tbody tr {
+  @apply text-sm text-gray-500;
+}
+
+td,
+th {
+  @apply py-2 px-3;
+}
+</style>

--- a/woonuxt_base/app/composables/useAuth.ts
+++ b/woonuxt_base/app/composables/useAuth.ts
@@ -8,7 +8,7 @@ export const useAuth = () => {
   const viewer = useState<Viewer | null>('viewer', () => null);
   const isPending = useState<boolean>('isPending', () => false);
   const orders = useState<Order[] | null>('orders', () => null);
-  const downloadableOrders = useState<Order[] | null>('downloadableOrders', () => null);
+  const downloads = useState<Downloads | null>('downloads', () => null);
 
   // Log in the user
   const loginUser = async (credentials: CreateAccountInput): Promise<{ success: boolean; error: any }> => {
@@ -111,11 +111,27 @@ export const useAuth = () => {
       const { customer } = await GqlGetOrders();
       if (customer) {
         orders.value = customer.orders?.nodes ?? [];
-        downloadableOrders.value = orders.value?.filter(order => (order?.downloadableItems?.nodes.length ?? 0) > 0);
         return { success: true, error: null };
       }
       return { success: false, error: 'There was an error getting your orders. Please try again later.' };
     } catch (error: any) {
+      const gqlError = error?.gqlErrors?.[0];
+      return { success: false, error: gqlError?.message };
+    }
+  };
+
+  const getDownloads = async (): Promise<{ success: boolean; error: any }> => {
+    try {
+      console.log("here")
+      const { customer } = await GqlGetDownloads();
+      if (customer) {
+        downloads.value = customer;
+        return { success: true, error: null };
+      }
+      return { success: false, error: 'There was an error getting your orders. Please try again later.' };
+    } catch (error: any) {
+      console.log("erroir", error);
+
       const gqlError = error?.gqlErrors?.[0];
       return { success: false, error: gqlError?.message };
     }
@@ -128,7 +144,7 @@ export const useAuth = () => {
     customer,
     isPending,
     orders,
-    downloadableOrders,
+    downloads,
     avatar,
     loginUser,
     updateCustomer,
@@ -137,5 +153,6 @@ export const useAuth = () => {
     registerUser,
     sendResetPasswordEmail,
     getOrders,
+    getDownloads,
   };
 };

--- a/woonuxt_base/app/composables/useAuth.ts
+++ b/woonuxt_base/app/composables/useAuth.ts
@@ -8,6 +8,7 @@ export const useAuth = () => {
   const viewer = useState<Viewer | null>('viewer', () => null);
   const isPending = useState<boolean>('isPending', () => false);
   const orders = useState<Order[] | null>('orders', () => null);
+  const downloadableOrders = useState<Order[] | null>('downloadableOrders', () => null);
 
   // Log in the user
   const loginUser = async (credentials: CreateAccountInput): Promise<{ success: boolean; error: any }> => {
@@ -110,6 +111,7 @@ export const useAuth = () => {
       const { customer } = await GqlGetOrders();
       if (customer) {
         orders.value = customer.orders?.nodes ?? [];
+        downloadableOrders.value = orders.value?.filter(order => (order?.downloadableItems?.nodes.length ?? 0) > 0);
         return { success: true, error: null };
       }
       return { success: false, error: 'There was an error getting your orders. Please try again later.' };
@@ -126,6 +128,7 @@ export const useAuth = () => {
     customer,
     isPending,
     orders,
+    downloadableOrders,
     avatar,
     loginUser,
     updateCustomer,

--- a/woonuxt_base/app/composables/useAuth.ts
+++ b/woonuxt_base/app/composables/useAuth.ts
@@ -122,7 +122,6 @@ export const useAuth = () => {
 
   const getDownloads = async (): Promise<{ success: boolean; error: any }> => {
     try {
-      console.log("here")
       const { customer } = await GqlGetDownloads();
       if (customer) {
         downloads.value = customer;
@@ -130,8 +129,6 @@ export const useAuth = () => {
       }
       return { success: false, error: 'There was an error getting your orders. Please try again later.' };
     } catch (error: any) {
-      console.log("erroir", error);
-
       const gqlError = error?.gqlErrors?.[0];
       return { success: false, error: gqlError?.message };
     }

--- a/woonuxt_base/app/composables/useAuth.ts
+++ b/woonuxt_base/app/composables/useAuth.ts
@@ -8,7 +8,7 @@ export const useAuth = () => {
   const viewer = useState<Viewer | null>('viewer', () => null);
   const isPending = useState<boolean>('isPending', () => false);
   const orders = useState<Order[] | null>('orders', () => null);
-  const downloads = useState<Downloads | null>('downloads', () => null);
+  const downloads = useState<DownloadableItem[] | null>('downloads', () => null);
 
   // Log in the user
   const loginUser = async (credentials: CreateAccountInput): Promise<{ success: boolean; error: any }> => {
@@ -124,10 +124,10 @@ export const useAuth = () => {
     try {
       const { customer } = await GqlGetDownloads();
       if (customer) {
-        downloads.value = customer;
+        downloads.value = customer.downloadableItems?.nodes ?? [];
         return { success: true, error: null };
       }
-      return { success: false, error: 'There was an error getting your orders. Please try again later.' };
+      return { success: false, error: 'There was an error getting your downloads. Please try again later.' };
     } catch (error: any) {
       const gqlError = error?.gqlErrors?.[0];
       return { success: false, error: gqlError?.message };

--- a/woonuxt_base/app/locales/de-DE.json
+++ b/woonuxt_base/app/locales/de-DE.json
@@ -17,6 +17,7 @@
       "myDetails": "Meine Details",
       "home": "Startseite",
       "allProducts": "Alle Produkte",
+      "product": "Produkt",
       "contact": "Kontakt",
       "menu": "Menü",
       "color": "Farbe",
@@ -28,6 +29,7 @@
       "clear": "Löschen",
       "optional": "Optional",
       "downloads": "Downloads",
+      "download": "Download",
       "goHome": "Zur Startseite",
       "newsletter": "Newsletter",
       "customerService": "Kundenservice",
@@ -107,7 +109,9 @@
       "discount": "Rabatt",
       "giftCards": "Geschenkkarten",
       "searchProducts": "Produkte suchen...",
-      "couponCode": "Gutscheincode"
+      "couponCode": "Gutscheincode",
+      "downloadsRemaining": "Verbleibende Downloads",
+      "expires": "Läuft ab"
     },
     "billing": {
       "billing": "Rechnung",

--- a/woonuxt_base/app/locales/en-US.json
+++ b/woonuxt_base/app/locales/en-US.json
@@ -17,6 +17,7 @@
       "myDetails": "My Details",
       "home": "Home",
       "allProducts": "Products",
+      "product": "Product",
       "contact": "Contact",
       "menu": "Menu",
       "color": "Color",
@@ -28,6 +29,7 @@
       "clear": "Clear",
       "optional": "Optional",
       "downloads": "Downloads",
+      "download": "Download",
       "goHome": "Go Home",
       "newsletter": "Newsletter",
       "customerService": "Customer Service",
@@ -107,7 +109,9 @@
       "discount": "Discount",
       "giftCards": "Gift Cards",
       "searchProducts": "Search Products...",
-      "couponCode": "Coupon Code"
+      "couponCode": "Coupon Code",
+      "downloadsRemaining": "Downloads remaining",
+      "expires": "Expires"
     },
     "billing": {
       "billing": "Billing",

--- a/woonuxt_base/app/locales/es-ES.json
+++ b/woonuxt_base/app/locales/es-ES.json
@@ -17,6 +17,7 @@
       "myDetails": "Mis detalles",
       "home": "Inicio",
       "allProducts": "Todos los productos",
+      "product": "Producto",
       "contact": "Contacto",
       "menu": "Menú",
       "color": "Color",
@@ -28,6 +29,7 @@
       "clear": "Limpiar",
       "optional": "Opcional",
       "downloads": "Descargas",
+      "download": "Descargar",
       "goHome": "Ir a inicio",
       "newsletter": "Boletín",
       "customerService": "Servicio al cliente",
@@ -107,7 +109,9 @@
       "discount": "Descuento",
       "giftCards": "Tarjetas de regalo",
       "searchProducts": "Buscar productos...",
-      "couponCode": "Código de cupón"
+      "couponCode": "Código de cupón",
+      "downloadsRemaining": "Descargas restantes",
+      "expires": "Expira"
     },
     "billing": {
       "billing": "Facturación",

--- a/woonuxt_base/app/locales/fr-FR.json
+++ b/woonuxt_base/app/locales/fr-FR.json
@@ -17,6 +17,7 @@
       "myDetails": "Mes informations",
       "home": "Accueil",
       "allProducts": "Tous les produits",
+      "product": "Produit",
       "contact": "Contact",
       "menu": "Menu",
       "color": "Couleur",
@@ -28,6 +29,7 @@
       "clear": "Effacer",
       "optional": "Optionnel",
       "downloads": "Téléchargements",
+      "download": "Télécharger",
       "goHome": "Retour à l'accueil",
       "newsletter": "Newsletter",
       "customerService": "Service Client",
@@ -107,7 +109,9 @@
       "discount": "Remise",
       "giftCards": "Cartes cadeaux",
       "searchProducts": "Rechercher par produit...",
-      "couponCode": "Code du coupon de réduction"
+      "couponCode": "Code du coupon de réduction",
+      "downloadsRemaining": "Téléchargements restants",
+      "expires": "Expire le"
     },
     "billing": {
       "billing": "Facturation",

--- a/woonuxt_base/app/locales/it-IT.json
+++ b/woonuxt_base/app/locales/it-IT.json
@@ -17,6 +17,7 @@
       "myDetails": "I miei dettagli",
       "home": "Home",
       "allProducts": "Prodotti",
+      "product": "Prodotto",
       "contact": "Contatto",
       "menu": "Menu",
       "color": "Colore",
@@ -28,6 +29,7 @@
       "clear": "Cancella",
       "optional": "Opzionale",
       "downloads": "Download",
+      "download": "Scarica",
       "goHome": "Torna alla Home",
       "newsletter": "Newsletter",
       "customerService": "Servizio clienti",
@@ -107,7 +109,9 @@
       "discount": "Sconto",
       "giftCards": "Carte regalo",
       "searchProducts": "Cerca prodotti...",
-      "couponCode": "Codice coupon"
+      "couponCode": "Codice coupon",
+      "downloadsRemaining": "Download rimanenti",
+      "expires": "Scade"
     },
     "billing": {
       "billing": "Fatturazione",

--- a/woonuxt_base/app/locales/pt-BR.json
+++ b/woonuxt_base/app/locales/pt-BR.json
@@ -17,6 +17,7 @@
       "myDetails": "Meus Detalhes",
       "home": "Início",
       "allProducts": "Produtos",
+      "product": "Produto",
       "contact": "Contato",
       "menu": "Menu",
       "color": "Cor",
@@ -28,6 +29,7 @@
       "clear": "Limpar",
       "optional": "Opcional",
       "downloads": "Downloads",
+      "download": "Download",
       "goHome": "Ir para Início",
       "newsletter": "Newsletter",
       "customerService": "Atendimento ao Cliente",
@@ -107,7 +109,9 @@
       "discount": "Desconto",
       "giftCards": "Cartões Presente",
       "searchProducts": "Pesquisar Produtos...",
-      "couponCode": "Código do Cupom"
+      "couponCode": "Código do Cupom",
+      "downloadsRemaining": "Downloads restantes",
+      "expires": "Expira"
     },
     "billing": {
       "billing": "Cobrança",

--- a/woonuxt_base/app/pages/my-account.vue
+++ b/woonuxt_base/app/pages/my-account.vue
@@ -44,6 +44,7 @@ const showLoader = computed(() => !viewer && !customer);
         <main class="flex-1 w-full lg:my-8 rounded-lg">
           <AccountMyDetails v-if="activeTab === 'my-details'" :user="viewer" />
           <OrderList v-else-if="activeTab === 'orders'" />
+          <DownloadList v-else-if="activeTab === 'downloads'" />
         </main>
       </div>
     </template>

--- a/woonuxt_base/app/pages/my-account.vue
+++ b/woonuxt_base/app/pages/my-account.vue
@@ -5,6 +5,10 @@ const route = useRoute();
 
 const activeTab = computed(() => route.query.tab || 'my-details');
 const showLoader = computed(() => !viewer && !customer);
+
+useSeoMeta({
+  title: `My Account`,
+});
 </script>
 
 <template>

--- a/woonuxt_base/app/pages/order-summary.vue
+++ b/woonuxt_base/app/pages/order-summary.vue
@@ -129,6 +129,11 @@ const refreshOrder = async () => {
 
         <hr class="my-8" />
 
+        <div v-if="order.downloadableItems.nodes">
+          <DownloadableItems :downloadableItems="order.downloadableItems.nodes" />
+          <hr class="my-8" />
+        </div>
+
         <div>
           <div class="flex justify-between">
             <span>{{ $t('messages.shop.subtotal') }}</span>

--- a/woonuxt_base/app/pages/order-summary.vue
+++ b/woonuxt_base/app/pages/order-summary.vue
@@ -14,7 +14,7 @@ const errorMessage = ref('');
 const isGuest = computed(() => !customer.value?.databaseId);
 const isSummaryPage = computed(() => name === 'order-summary');
 const isCheckoutPage = computed(() => name === 'order-received');
-const orderIsNotComplet = computed(() => order.value.status !== OrderStatusEnum.COMPLETED);
+const orderIsNotCompleted = computed(() => order.value.status !== OrderStatusEnum.COMPLETED);
 const hasDiscount = computed<boolean>(() => !!parseFloat(order.value.discountTotal?.replace(/[^0-9.]/g, '')));
 
 onBeforeMount(() => {
@@ -73,7 +73,7 @@ const refreshOrder = async () => {
           <div class="flex w-full items-center justify-between mb-2">
             <h1 class="text-xl font-semibold">{{ $t('messages.shop.orderReceived') }}</h1>
             <button
-              v-if="orderIsNotComplet"
+              v-if="orderIsNotCompleted"
               type="button"
               class="border rounded-md p-2 inline-flex items-center justify-center bg-white"
               title="Refresh order"
@@ -129,7 +129,7 @@ const refreshOrder = async () => {
 
         <hr class="my-8" />
 
-        <div v-if="order.downloadableItems?.nodes && order.downloadableItems.nodes.length && !orderIsNotComplet">
+        <div v-if="order.downloadableItems?.nodes && order.downloadableItems.nodes.length && !orderIsNotCompleted">
           <DownloadableItems :downloadableItems="order.downloadableItems.nodes" />
           <hr class="my-8" />
         </div>

--- a/woonuxt_base/app/pages/order-summary.vue
+++ b/woonuxt_base/app/pages/order-summary.vue
@@ -14,7 +14,7 @@ const errorMessage = ref('');
 const isGuest = computed(() => !customer.value?.databaseId);
 const isSummaryPage = computed(() => name === 'order-summary');
 const isCheckoutPage = computed(() => name === 'order-received');
-const showRefreshButton = computed(() => order.value.status !== OrderStatusEnum.COMPLETED);
+const orderIsNotComplet = computed(() => order.value.status !== OrderStatusEnum.COMPLETED);
 const hasDiscount = computed<boolean>(() => !!parseFloat(order.value.discountTotal?.replace(/[^0-9.]/g, '')));
 
 onBeforeMount(() => {
@@ -73,7 +73,7 @@ const refreshOrder = async () => {
           <div class="flex w-full items-center justify-between mb-2">
             <h1 class="text-xl font-semibold">{{ $t('messages.shop.orderReceived') }}</h1>
             <button
-              v-if="showRefreshButton"
+              v-if="orderIsNotComplet"
               type="button"
               class="border rounded-md p-2 inline-flex items-center justify-center bg-white"
               title="Refresh order"
@@ -109,7 +109,7 @@ const refreshOrder = async () => {
         <hr class="my-8" />
 
         <div class="grid gap-2">
-          <div v-if="order.lineItems" v-for="item in order.lineItems.nodes" :key="item.product?.databaseId!" class="flex items-center justify-between gap-8">
+          <div v-if="order.lineItems" v-for="item in order.lineItems.nodes" :key="item.id" class="flex items-center justify-between gap-8">
             <img
               v-if="item.product?.node"
               class="w-16 h-16 rounded-xl"
@@ -129,7 +129,7 @@ const refreshOrder = async () => {
 
         <hr class="my-8" />
 
-        <div v-if="order.downloadableItems.nodes">
+        <div v-if="order.downloadableItems?.nodes && order.downloadableItems.nodes.length && !orderIsNotComplet">
           <DownloadableItems :downloadableItems="order.downloadableItems.nodes" />
           <hr class="my-8" />
         </div>

--- a/woonuxt_base/app/queries/getDownloads.gql
+++ b/woonuxt_base/app/queries/getDownloads.gql
@@ -1,0 +1,17 @@
+query getDownloads {
+  customer {
+    downloadableItems {
+      nodes {
+        id
+        name
+        product {
+          name
+          slug
+        }
+        url
+        accessExpires
+        downloadsRemaining
+      }
+    }
+  }
+}

--- a/woonuxt_base/app/queries/getOrder.gql
+++ b/woonuxt_base/app/queries/getOrder.gql
@@ -21,13 +21,13 @@ query getOrder($id: ID!) {
     downloadableItems {
       nodes {
         name
-        downloadsRemaining
-        url
         product {
           name
           slug
         }
+        url
         accessExpires
+        downloadsRemaining
       }
     }
     lineItems {

--- a/woonuxt_base/app/queries/getOrder.gql
+++ b/woonuxt_base/app/queries/getOrder.gql
@@ -18,6 +18,18 @@ query getOrder($id: ID!) {
     customer {
       email
     }
+    downloadableItems {
+      nodes {
+        name
+        downloadsRemaining
+        url
+        product {
+          name
+          slug
+        }
+        accessExpires
+      }
+    }
     lineItems {
       nodes {
         quantity

--- a/woonuxt_base/app/queries/getOrder.gql
+++ b/woonuxt_base/app/queries/getOrder.gql
@@ -25,15 +25,19 @@ query getOrder($id: ID!) {
           name
           slug
         }
-        url
         accessExpires
         downloadsRemaining
+        download {
+          file
+          name
+        }
       }
     }
     lineItems {
       nodes {
         quantity
         total
+        id
         product {
           node {
             name

--- a/woonuxt_base/app/queries/getOrders.gql
+++ b/woonuxt_base/app/queries/getOrders.gql
@@ -9,13 +9,13 @@ query getOrders {
         downloadableItems {
           nodes {
             name
-            downloadsRemaining
-            url
             product {
               name
               slug
             }
+            url
             accessExpires
+            downloadsRemaining
           }
         }
         lineItems {

--- a/woonuxt_base/app/queries/getOrders.gql
+++ b/woonuxt_base/app/queries/getOrders.gql
@@ -6,6 +6,18 @@ query getOrders {
         total
         date
         status
+        downloadableItems {
+          nodes {
+            name
+            downloadsRemaining
+            url
+            product {
+              name
+              slug
+            }
+            accessExpires
+          }
+        }
         lineItems {
           nodes {
             product {

--- a/woonuxt_base/app/queries/getOrders.gql
+++ b/woonuxt_base/app/queries/getOrders.gql
@@ -6,18 +6,6 @@ query getOrders {
         total
         date
         status
-        downloadableItems {
-          nodes {
-            name
-            product {
-              name
-              slug
-            }
-            url
-            accessExpires
-            downloadsRemaining
-          }
-        }
         lineItems {
           nodes {
             product {

--- a/woonuxt_base/app/types/index.d.ts
+++ b/woonuxt_base/app/types/index.d.ts
@@ -2,12 +2,12 @@ type Cart = import('#gql').GetCartQuery['cart'];
 type Customer = import('#gql').GetCartQuery['customer'];
 type Viewer = import('#gql').GetCartQuery['viewer'];
 type PaymentGateways = import('#gql').GetCartQuery['paymentGateways'];
-type ProducBase = import('#gql').GetProductQuery['product'];
+type ProductBase = import('#gql').GetProductQuery['product'];
 type Order = import('#gql').GetOrderQuery['order'];
 type Downloads = import('#gql').GetDownloadsQuery['customer']
 type SimpleProduct = import('#gql').SimpleProductFragment;
 type VariableProduct = import('#gql').VariableProductFragment;
-type Product = ProducBase & SimpleProduct & VariableProduct;
+type Product = ProductBase & SimpleProduct & VariableProduct;
 
 interface ProductAttributeInput {
   attributeName: string;

--- a/woonuxt_base/app/types/index.d.ts
+++ b/woonuxt_base/app/types/index.d.ts
@@ -4,6 +4,7 @@ type Viewer = import('#gql').GetCartQuery['viewer'];
 type PaymentGateways = import('#gql').GetCartQuery['paymentGateways'];
 type ProducBase = import('#gql').GetProductQuery['product'];
 type Order = import('#gql').GetOrderQuery['order'];
+type Downloads = import('#gql').GetDownloadsQuery['customer']
 type SimpleProduct = import('#gql').SimpleProductFragment;
 type VariableProduct = import('#gql').VariableProductFragment;
 type Product = ProducBase & SimpleProduct & VariableProduct;

--- a/woonuxt_base/app/types/index.d.ts
+++ b/woonuxt_base/app/types/index.d.ts
@@ -4,7 +4,6 @@ type Viewer = import('#gql').GetCartQuery['viewer'];
 type PaymentGateways = import('#gql').GetCartQuery['paymentGateways'];
 type ProductBase = import('#gql').GetProductQuery['product'];
 type Order = import('#gql').GetOrderQuery['order'];
-type Downloads = import('#gql').GetDownloadsQuery['customer']
 type SimpleProduct = import('#gql').SimpleProductFragment;
 type VariableProduct = import('#gql').VariableProductFragment;
 type Product = ProductBase & SimpleProduct & VariableProduct;
@@ -139,4 +138,18 @@ interface WooNuxtSEOItem {
   provider: string;
   url?: string;
   handle?: string;
+}
+
+interface DownloadableProduct {
+  slug?: string | null;
+  name?: string | null;
+}
+
+interface DownloadableItem {
+  id: string;
+  product?: DownloadableProduct | null;
+  downloadsRemaining?: number | null;
+  accessExpires?: string | null;
+  url?: string | null;
+  name?: string | null;
 }

--- a/woonuxt_base/app/types/index.d.ts
+++ b/woonuxt_base/app/types/index.d.ts
@@ -141,15 +141,15 @@ interface WooNuxtSEOItem {
 }
 
 interface DownloadableProduct {
-  slug?: string | null;
-  name?: string | null;
+  slug: string;
+  name: string;
 }
 
 interface DownloadableItem {
   id: string;
-  product?: DownloadableProduct | null;
+  product: DownloadableProduct;
   downloadsRemaining?: number | null;
-  accessExpires?: string | null;
   url?: string | null;
-  name?: string | null;
+  accessExpires?: string | null;
+  name: string | null;
 }


### PR DESCRIPTION
Implemented a new component mirroring the Orders List for WooCommerce to display downloadable products. 


![Screenshot 2024-06-25 at 04 58 59](https://github.com/scottyzen/woonuxt/assets/9624843/ee6614ba-09f1-464a-8af8-47ed89d1ec6f)

![Screenshot 2024-06-25 at 04 29 12](https://github.com/scottyzen/woonuxt/assets/9624843/520b0ebd-842f-4193-b547-734fb776810f)


This update includes:

- Enhanced getOrders and getOrder functions to incorporate download information for orders containing downloadable products.
- Integration of translations for improved multilingual support.
- User-friendly interface similar to the WooCommerce account section, enhancing usability.

Kindly review and integrate these enhancements for a seamless customer experience with downloadable products.

Let me know what you think @scottyzen 