### PR TITLE
Fix Product defaultAttributes for dropdown & checkboxes

### DIFF
--- a/woonuxt_base/app/components/productElements/AttributeSelections.vue
+++ b/woonuxt_base/app/components/productElements/AttributeSelections.vue
@@ -26,8 +26,8 @@ const setDefaultAttributes = () => {
   if (defaultAttributes?.nodes) {
     defaultAttributes?.nodes.forEach((attr: Attribute) => {
       const radio = document.querySelector(`.name-${attr.name}[value="${attr.value}"]`) as HTMLInputElement;
-      const dropdown = document.querySelector(`#${attr.name}[value="${attr.value}"]`) as HTMLSelectElement;
       if (radio) radio.checked = true;
+      const dropdown = document.querySelector(`#${attr.name}`) as HTMLSelectElement;
       if (dropdown) dropdown.value = attr.value;
     });
   }
@@ -74,7 +74,7 @@ onMounted(() => {
         </div>
         <select :id="attr.name" :ref="attr.name" :name="attr.name" required class="border-white shadow" @change="updateAttrs">
           <option disabled hidden>{{ $t('messages.general.choose') }} {{ decodeURIComponent(attr.label) }}</option>
-          <option v-for="(option, dropdownIndex) in attr.options" :key="option" :value="option" v-html="option" :selected="dropdownIndex == 0" />
+          <option v-for="(option, dropdownIndex) in attr.options" :key="dropdownIndex" :value="option" v-html="option" :selected="dropdownIndex == 0" />
         </select>
       </div>
 

--- a/woonuxt_base/app/queries/getProduct.gql
+++ b/woonuxt_base/app/queries/getProduct.gql
@@ -45,14 +45,7 @@ query getProduct($slug: ID!) {
     }
     ...Terms
     ...SimpleProduct
-    ... on VariableProduct {
-      defaultAttributes {
-        nodes {
-          name
-          value
-        }
-      }
-    }
+    ...VariableProduct
     related(first: 5) {
       nodes {
         name

--- a/woonuxt_base/app/queries/getProduct.gql
+++ b/woonuxt_base/app/queries/getProduct.gql
@@ -45,7 +45,14 @@ query getProduct($slug: ID!) {
     }
     ...Terms
     ...SimpleProduct
-    ...VariableProduct
+    ... on VariableProduct {
+      defaultAttributes {
+        nodes {
+          name
+          value
+        }
+      }
+    }
     related(first: 5) {
       nodes {
         name


### PR DESCRIPTION
This PR addresses the issue where default attributes for Dropdowns and Checkboxes on the SingleProduct page were not being applied correctly after selection in WordPress.

Changes include:

GraphQL Query Update: Included defaultAttributes in the GraphQL query to fetch default attribute values.
Vue Component Fix: Enhanced the logic for setting default values in Dropdowns and Checkboxes to ensure proper selection.

Feel free to review @scottyzen 