### PR TITLE
Adjust translations and improve login

### DIFF
--- a/woonuxt_base/app/components/forms/LoginAndRegister.vue
+++ b/woonuxt_base/app/components/forms/LoginAndRegister.vue
@@ -15,20 +15,21 @@
 
     <form class="mt-6" @submit.prevent="handleFormSubmit(userInfo)">
       <label v-if="formView === 'register' || formView === 'forgotPassword'" for="email">
-        {{ (formView === 'register') ? $t('messages.billing.email') : $t('messages.account.emailOrUsername') }}
+        {{ emailLabel }}
         <span class="text-red-500">*</span> <br />
-        <input id="email" v-model="userInfo.email" placeholder="Email" type="text" required />
+        <input id="email" v-model="userInfo.email" :placeholder="inputPlaceholder.email" type="text" required />
       </label>
-      <p v-if="formView === 'forgotPassword'" class="text-sm text-gray-500">{{ $t('messages.account.enterEmailForReset') }}</p>
+      <p v-if="formView === 'forgotPassword'" class="text-sm text-gray-500">{{ $t('messages.account.enterEmailOrUsernameForReset') }}</p>
       <div v-if="formView !== 'forgotPassword'">
         <label for="username">
-          {{ (formView === 'login') ? $t('messages.account.emailOrUsername') : $t('messages.account.username') }}
+          {{ usernameLabel }}
           <span class="text-red-500">*</span> <br />
-          <input id="username" v-model="userInfo.username" placeholder="Username" type="text" required />
+          <input id="username" v-model="userInfo.username" :placeholder="inputPlaceholder.username" type="text" required />
         </label>
         <label for="password">
-          {{ $t('messages.account.password') }} <span class="text-red-500">*</span> <br />
-          <PasswordInput id="password" className="border rounded-lg w-full p-3 px-4 bg-white" v-model="userInfo.password" placeholder="Password" :required="true" />
+          {{ passwordLabel }} <span class="text-red-500">*</span> <br />
+          <PasswordInput id="password" className="border rounded-lg w-full p-3 px-4 bg-white" v-model="userInfo.password" :placeholder="inputPlaceholder.password"
+          :required="true" />
         </label>
       </div>
       <Transition name="scale-y" mode="out-in">
@@ -147,6 +148,27 @@ const buttonText = computed(() => {
     return t('messages.account.sendPasswordResetEmail');
   }
 });
+
+const emailLabel = computed(() => {
+  return (formView.value === 'register') ? t('messages.billing.email') : t('messages.account.emailOrUsername');
+});
+
+const usernameLabel = computed(() => {
+  return (formView.value === 'login') ? t('messages.account.emailOrUsername') : t('messages.account.username');
+});
+
+const passwordLabel = computed(() => {
+  return t('messages.account.password');
+});
+
+const inputPlaceholder = computed(() => {
+  return {
+    email: emailLabel.value,
+    username: usernameLabel.value,
+    password: passwordLabel.value,
+  };
+});
+
 </script>
 
 <style lang="postcss" scoped>

--- a/woonuxt_base/app/locales/de-DE.json
+++ b/woonuxt_base/app/locales/de-DE.json
@@ -48,7 +48,7 @@
       "login": "Anmelden",
       "logout": "Logout",
       "backToLogin": "Zurück zum Login",
-      "enterEmailForReset": "Bitte geben Sie Ihre E-Mail-Adresse ein, und wir senden Ihnen einen Link zum Zurücksetzen Ihres Passworts.",
+      "enterEmailOrUsernameForReset": "Bitte geben Sie Ihre E-Mail-Adresse oder Ihren Benutzernamen ein, und wir senden Ihnen einen Link zum Zurücksetzen Ihres Passworts.",
       "ifRegistered": "Wenn Ihre E-Mail-Adresse bei uns registriert ist, erhalten Sie eine E-Mail mit einem Link zum Zurücksetzen Ihres Passworts.",
       "requestNewLink": "Bitte fordern Sie einen neuen Link an",
       "resetPassword": "Passwort zurücksetzen",

--- a/woonuxt_base/app/locales/en-US.json
+++ b/woonuxt_base/app/locales/en-US.json
@@ -48,7 +48,7 @@
       "login": "Log In",
       "logout": "Logout",
       "backToLogin": "Back to Login",
-      "enterEmailForReset": "Please enter your email address or username and we will send you a link to reset your password.",
+      "enterEmailOrUsernameForReset": "Please enter your email address or username and we will send you a link to reset your password.",
       "ifRegistered": "If your email address is registered with us, you will receive an email with a link to reset your password.",
       "requestNewLink": "Please request a new link",
       "resetPassword": "Reset password",

--- a/woonuxt_base/app/locales/es-ES.json
+++ b/woonuxt_base/app/locales/es-ES.json
@@ -48,7 +48,7 @@
       "login": "Iniciar sesión",
       "logout": "Cerrar sesión",
       "backToLogin": "Volver a Iniciar sesión",
-      "enterEmailForReset": "Ingrese su dirección de correo electrónico y le enviaremos un enlace para restablecer su contraseña.",
+      "enterEmailOrUsernameForReset": "Ingrese su dirección de correo electrónico o nombre de usuario y le enviaremos un enlace para restablecer su contraseña.",
       "ifRegistered": "Si tu dirección de correo electrónico está registrada con nosotros, recibirás un correo electrónico con un enlace para restablecer tu contraseña.",
       "requestNewLink": "Solicita un nuevo enlace",
       "resetPassword": "Restablecer la contraseña",

--- a/woonuxt_base/app/locales/fr-FR.json
+++ b/woonuxt_base/app/locales/fr-FR.json
@@ -48,7 +48,7 @@
       "login": "Se connecter",
       "logout": "Se déconnecter",
       "backToLogin": "Retour à la connexion",
-      "enterEmailForReset": "Veuillez entrer votre adresse e-mail et nous vous enverrons un lien pour réinitialiser votre mot de passe.",
+      "enterEmailOrUsernameForReset": "Veuillez entrer votre adresse e-mail ou votre nom d'utilisateur et nous vous enverrons un lien pour réinitialiser votre mot de passe.",
       "ifRegistered": "Si votre adresse e-mail est enregistrée chez nous, vous recevrez un e-mail contenant un lien pour réinitialiser votre mot de passe.",
       "requestNewLink": "Veuillez demander un nouveau lien",
       "resetPassword": "Réinitialiser le mot de passe",

--- a/woonuxt_base/app/locales/it-IT.json
+++ b/woonuxt_base/app/locales/it-IT.json
@@ -48,7 +48,7 @@
       "login": "Accedi",
       "logout": "Esci",
       "backToLogin": "Torna al Login",
-      "enterEmailForReset": "Inserisci il tuo indirizzo e-mail e ti invieremo un link per reimpostare la tua password.",
+      "enterEmailOrUsernameForReset": "Inserisci il tuo indirizzo e-mail o nome utente e ti invieremo un link per reimpostare la tua password.",
       "ifRegistered": "Se il tuo indirizzo e-mail è registrato presso di noi, riceverai un'e-mail con un link per reimpostare la tua password.",
       "requestNewLink": "Richiedi un nuovo link",
       "resetPassword": "Reimposta password",

--- a/woonuxt_base/app/locales/pt-BR.json
+++ b/woonuxt_base/app/locales/pt-BR.json
@@ -48,7 +48,7 @@
       "login": "Entrar",
       "logout": "Sair",
       "backToLogin": "Voltar ao Login",
-      "enterEmailForReset": "Por favor, insira seu endereço de e-mail e enviaremos um link para redefinir sua senha.",
+      "enterEmailOrUsernameForReset": "Por favor, insira seu endereço de e-mail ou nome de usuário e enviaremos um link para redefinir sua senha.",
       "ifRegistered": "Se o seu endereço de e-mail estiver registrado conosco, você receberá um e-mail com um link para redefinir sua senha.",
       "requestNewLink": "Solicite um novo link",
       "resetPassword": "Redefinir senha",


### PR DESCRIPTION
After the PR merge I noticed some minor issues in LoginAndRegister component. 

Fixed the translations to include the username for forgot password and fixed the placeholders to use also the translations.