### PR TITLE
Make Nuxt public env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,10 +6,10 @@ GQL_HOST="https://example.com/graphql"
 # If you don't have the plugin installed, you can configure the rest of the settings here.
 
 # number of products to be displayed per page
-PRODUCTS_PER_PAGE="24"
+NUXT_PUBLIC_PRODUCTS_PER_PAGE="24"
 
 # Stripe API key
-STRIPE_PUBLISHABLE_KEY="pk_test_abcdefghijklmnopqrstuvwxyz"
+NUXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_abcdefghijklmnopqrstuvwxyz"
 
 # Color of input and button elements
 PRIMARY_COLOR="#ff0000"


### PR DESCRIPTION
This PR fixes the `STRIPE_PUBLISHABLE_KEY` env example, that in order to be in runtimeConfig.public needed to be starting: `NUXT_PUBLIC_`

Maybe WOO_NUXT_SEO & FRONT_END_URL, Have also to be added in .env.example @scottyzen  ?