### PR TITLE
Fix use icon provider

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,4 @@
 export default defineNuxtConfig({
-  future: {
-    compatibilityVersion: 4,
-  },
 
   // Get all the pages, components, composables and plugins from the parent theme
   extends: ['./woonuxt_base'],

--- a/woonuxt_base/nuxt.config.ts
+++ b/woonuxt_base/nuxt.config.ts
@@ -62,6 +62,12 @@ export default defineNuxtConfig({
     },
   },
 
+  // if nuxt generated this is needed 
+  // https://github.com/nuxt/icon/issues/179#issuecomment-2230860618
+  icon: {
+    provider: 'iconify'
+  },
+
   // Multilingual support
   i18n: {
     locales: [


### PR DESCRIPTION
compatibilityVersion is already defined in woonuxt_base/nuxt.config.ts
icon: provider: 'iconify' is needed when nuxt is statically generated