### PR TITLE
Minor - fix ResetPassword check

### DIFF
--- a/woonuxt_base/app/components/forms/ResetPassword.vue
+++ b/woonuxt_base/app/components/forms/ResetPassword.vue
@@ -10,6 +10,10 @@ const errorMessage = ref('');
 const isPending = ref(false);
 const isInvalidLink = ref(false);
 
+if (!route.query.key && !route.query.login) {
+  router.push('/my-account?action=forgotPassword');
+}
+
 const handlePasswordReset = async () => {
   try {
     errorMessage.value = '';


### PR DESCRIPTION
This PR adds a check if key and login are not defined as query params. they should be redirected to forgot password page.

This is an improvement when clicking on wp-login -> Lost password you get redirected to:
`{{ frontend url}}/my-account/lost-password/ ` without any params.

So user should see the field to enter his email for reset pass.