### PR TITLE
Fix Bug Failed to execute 'insertBefore' on 'Node - Change page transition to default

### DIFF
--- a/woonuxt_base/nuxt.config.ts
+++ b/woonuxt_base/nuxt.config.ts
@@ -12,7 +12,7 @@ export default defineNuxtConfig({
       htmlAttrs: { lang: 'en' },
       link: [{ rel: 'icon', href: '/logo.svg', type: 'image/svg+xml' }],
     },
-    pageTransition: { name: 'page', mode: 'out-in' },
+    pageTransition: { name: 'page', mode: 'default' },
   },
 
   experimental: {


### PR DESCRIPTION
This PR fixes this issue:
https://github.com/scottyzen/woonuxt/issues/206

Switching to default transition to fix crashing when navigating to pages.
Similar thread discussing the same issue:
https://github.com/nuxt/nuxt/issues/12735#issuecomment-1854837119
was to switch to default transition. After this change I did not encounter any crashes while switching to pages.