### PR TITLE
Enhance initStore to Initialize Immediately for Specific Pages

### DIFF
--- a/woonuxt_base/app/plugins/init.ts
+++ b/woonuxt_base/app/plugins/init.ts
@@ -57,11 +57,10 @@ export default defineNuxtPlugin(async (nuxtApp) => {
 
     // Check if the current route path is one of the pages that need immediate initialization
     const pagesToInitializeRightAway = ['/checkout', '/my-account', '/order-summary'];
-    const { path } = useRoute();
-    const shouldInitialize = pagesToInitializeRightAway.some(page => path.includes(page));
+    const isPathThatRequiresInit = pagesToInitializeRightAway.some(page => useRoute().path.includes(page));
 
-    if (isDev || shouldInitialize) {
-      initStore();
+    if (isDev || isPathThatRequiresInit) {
+      await initStore();
       return;
     }
 
@@ -70,7 +69,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
         window.addEventListener(event, initStore, { once: true });
       });
     } else {
-      initStore();
+      await initStore();
     }
   }
 });

--- a/woonuxt_base/app/plugins/init.ts
+++ b/woonuxt_base/app/plugins/init.ts
@@ -53,23 +53,20 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     }
 
     // If we are in development mode, we want to initialise the store immediately
-    const isDev = process.env.NODE_ENV === 'development'
-
+    const isDev = process.env.NODE_ENV === 'development';
+    
     // Check if the current route path is one of the pages that need immediate initialization
     const pagesToInitializeRightAway = ['/checkout', '/my-account', '/order-summary'];
     const isPathThatRequiresInit = pagesToInitializeRightAway.some(page => useRoute().path.includes(page));
 
-    if (isDev || isPathThatRequiresInit) {
-      await initStore();
-      return;
-    }
+    const shouldInit = isDev || isPathThatRequiresInit || !storeSettings.initStoreOnUserActionToReduceServerLoad;
 
-    if (storeSettings.initStoreOnUserActionToReduceServerLoad) {
+    if (shouldInit) {
+      await initStore();
+    } else {
       eventsToFireOn.forEach((event) => {
         window.addEventListener(event, initStore, { once: true });
       });
-    } else {
-      await initStore();
     }
   }
 });

--- a/woonuxt_base/app/plugins/init.ts
+++ b/woonuxt_base/app/plugins/init.ts
@@ -53,7 +53,14 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     }
 
     // If we are in development mode, we want to initialise the store immediately
-    if (process.env.NODE_ENV === 'development') {
+    const isDev = process.env.NODE_ENV === 'development'
+
+    // Check if the current route path is one of the pages that need immediate initialization
+    const pagesToInitializeRightAway = ['/checkout', '/my-account', '/order-summary'];
+    const { path } = useRoute();
+    const shouldInitialize = pagesToInitializeRightAway.some(page => path.includes(page));
+
+    if (isDev || shouldInitialize) {
       initStore();
       return;
     }


### PR DESCRIPTION
This PR addresses a problem where users on the `/my-account`, `/checkout`, or `/order-summary` pages need immediate access to the cart, potentially causing infinite loading issues described in [Issue #172](https://github.com/scottyzen/woonuxt/issues/172).

To fix this, the PR modifies the plugin to initialize the store immediately for these critical pages, bypassing the need for user interaction (e.g., scrolling or clicking) to trigger cart updates.

Changes:

Added immediate store initialization for /my-account, /checkout, and /order-summary pages.
Ensured that this initialization happens specifically for users with storeSettings.initStoreOnUserActionToReduceServerLoad set to true (which is the default setting).

This ensures that users on these pages get up-to-date cart information right away, improving user experience and preventing potential infinite loop issues. For other pages or settings, the store will continue to initialize based on user interactions as configured.