### PR TITLE
Fix LoadingIcon Uniqueness

### DIFF
--- a/woonuxt_base/app/components/generalElements/LoadingIcon.vue
+++ b/woonuxt_base/app/components/generalElements/LoadingIcon.vue
@@ -5,12 +5,14 @@ defineProps({
   speed: { default: '250ms', type: String },
   stroke: { default: '2.5', type: String || Number },
 });
+
+const gradientId = useId();
 </script>
 
 <template>
   <svg :width="size" :height="size" viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg">
     <defs>
-      <linearGradient id="a" x1="8.042%" y1="0%" x2="65.682%" y2="23.865%">
+      <linearGradient :id="gradientId" x1="8.042%" y1="0%" x2="65.682%" y2="23.865%">
         <stop :stop-color="color" stop-opacity="0" offset="0%" />
         <stop :stop-color="color" stop-opacity=".631" offset="63.146%" />
         <stop :stop-color="color" offset="100%" />
@@ -18,7 +20,7 @@ defineProps({
     </defs>
     <g fill="none" fill-rule="evenodd">
       <g transform="translate(1 1)">
-        <path id="Oval-2" d="M36 18c0-9.94-8.06-18-18-18" stroke="url(#a)" :stroke-width="stroke">
+        <path id="Oval-2" d="M36 18c0-9.94-8.06-18-18-18" :stroke="`url(#${gradientId})`" :stroke-width="stroke">
           <animateTransform attributeName="transform" type="rotate" from="0 18 18" to="360 18 18" :dur="speed" repeatCount="indefinite" />
         </path>
         <circle fill="#fff" cx="36" cy="18" r="1">


### PR DESCRIPTION
Multiple instances of the LoadingIcon component were affecting each other due to a shared SVG id. `id="a"`

- This fix ensures each instance has a unique gradient ID.
- Prevents visual conflicts between multiple instances of the component.

before:

https://github.com/user-attachments/assets/1ad3c150-4c59-4536-ad17-c90f9db16626


after:


https://github.com/user-attachments/assets/2d12c678-d026-480a-8234-e915c0795b5a

