### PR TITLE
Logout using refreshCart

### DIFF
--- a/woonuxt_base/app/composables/useAuth.ts
+++ b/woonuxt_base/app/composables/useAuth.ts
@@ -2,7 +2,7 @@ import { GqlLogin, GqlLogout, GqlRegisterCustomer, GqlResetPasswordEmail, GqlGet
 import type { RegisterCustomerInput, CreateAccountInput } from '#gql';
 
 export const useAuth = () => {
-  const { refreshCart, emptyCart, cart } = useCart();
+  const { refreshCart, cart } = useCart();
   const { logGQLError, clearAllCookies } = useHelpers();
 
   const customer = useState<Customer>('customer', () => ({ billing: {}, shipping: {} }));
@@ -47,20 +47,21 @@ export const useAuth = () => {
 
   // Log out the user
   const logoutUser = async (): Promise<{ success: boolean; error: any }> => {
-    viewer.value = null;
-    cart.value = null;
-    customer.value = { billing: {}, shipping: {} };
-
+    isPending.value = true;
     try {
       const { logout } = await GqlLogout();
       if (logout) {
+        viewer.value = null;
+        cart.value = null;
+        customer.value = { billing: {}, shipping: {} };
         clearAllCookies();
-        await emptyCart();
       }
       return { success: true, error: null };
     } catch (error) {
       logGQLError(error);
       return { success: false, error };
+    } finally {
+      isPending.value = false;
     }
   };
 

--- a/woonuxt_base/app/composables/useAuth.ts
+++ b/woonuxt_base/app/composables/useAuth.ts
@@ -51,10 +51,10 @@ export const useAuth = () => {
     try {
       const { logout } = await GqlLogout();
       if (logout) {
-        viewer.value = null;
-        cart.value = null;
-        customer.value = { billing: {}, shipping: {} };
+        await refreshCart();
         clearAllCookies();
+        viewer.value = null;
+        customer.value = { billing: {}, shipping: {} };
       }
       return { success: true, error: null };
     } catch (error) {

--- a/woonuxt_base/app/pages/my-account/index.vue
+++ b/woonuxt_base/app/pages/my-account/index.vue
@@ -4,7 +4,7 @@ const { cart } = useCart();
 const route = useRoute();
 
 const activeTab = computed(() => route.query.tab || 'my-details');
-const showLoader = computed(() => !viewer && !customer);
+const showLoader = computed(() => !cart.value);
 
 useSeoMeta({
   title: `My Account`,

--- a/woonuxt_base/app/pages/my-account/index.vue
+++ b/woonuxt_base/app/pages/my-account/index.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-const { logoutUser, viewer, customer, avatar } = useAuth();
+const { logoutUser, viewer, customer, avatar, isPending } = useAuth();
 const { cart } = useCart();
 const route = useRoute();
 
@@ -13,7 +13,7 @@ useSeoMeta({
 
 <template>
   <div class="container min-h-[600px]">
-    <div v-if="showLoader || !cart" class="flex flex-col min-h-[500px]">
+    <div v-if="showLoader" class="flex flex-col min-h-[500px]">
       <LoadingIcon class="m-auto" />
     </div>
     <template v-else>
@@ -27,8 +27,8 @@ useSeoMeta({
               <span v-if="viewer?.email" class="text-gray-400 font-light" :title="viewer?.email">{{ viewer?.email }}</span>
             </div>
             <button class="flex text-gray-700 items-center flex-col p-2 px-4 rounded-lg hover:bg-white hover:text-red-700 lg:hidden" @click="logoutUser">
-              <LoadingIcon size="22" />
-              <Icon name="ion:log-out-outline" size="22" />
+              <LoadingIcon v-if="isPending" size="22" />
+              <Icon v-else name="ion:log-out-outline" size="22" />
               <small>{{ $t('messages.account.logout') }}</small>
             </button>
           </section>
@@ -54,7 +54,8 @@ useSeoMeta({
           <template class="hidden lg:block">
             <hr class="my-8" />
             <button class="flex text-gray-700 items-center gap-4 p-2 px-4 w-full rounded-lg hover:bg-white hover:text-red-700" @click="logoutUser">
-              <Icon name="ion:log-out-outline" size="22" />
+              <LoadingIcon v-if="isPending" size="22" />
+              <Icon v-else name="ion:log-out-outline" size="22" />
               {{ $t('messages.account.logout') }}
             </button>
           </template>


### PR DESCRIPTION
Since logout must happen server-side (because secure cookies cannot be removed client-side), we should rely on the server's logout response to confirm that the user has successfully logged out.

I identified the issue with the LoadingIcon in [PR #216](https://github.com/scottyzen/woonuxt/pull/216), which allows the logout loading to function properly. If the logout is successful, we can then reset the viewer and customer states.

### EmptyCart error - Infinite loader in my-account after logout:
The emptyCart GraphQL mutation is returning an **error**:
![Screenshot 2024-08-08 at 15 55 22](https://github.com/user-attachments/assets/6e39df0f-f189-409b-8ca2-b241aae9f770)

This results in an infinite loop after logout. I tested logout on [v3.woonuxt.com](https://v3.woonuxt.com/my-account/), and the response was error-free. Has this been tested with WOO_WP_GraphQL v0.20.0 | v0.20.1?

(showLoader in my-account should rely only in cart.value since plugin init() is using the cart to get an empty cart.)