### PR TITLE
Use `@update`  instead of `@change` for PriceFilter slider

### DIFF
--- a/woonuxt_base/app/components/filtering/PriceFilter.vue
+++ b/woonuxt_base/app/components/filtering/PriceFilter.vue
@@ -51,7 +51,7 @@ watch(isFiltersActive, () => {
         <label for="price-to" class="leading-none px-2 text-gray-400 absolute" v-html="currencySymbol" />
       </div>
       <div class="mx-1 mt-1 col-span-full">
-        <Slider v-model="price" :tooltips="false" :min="0" :max="maxPrice" ariaLabelledby="price-from price-to" @change="applyPrice" />
+        <Slider v-model="price" :tooltips="false" :min="0" :max="maxPrice" ariaLabelledby="price-from price-to" @update="applyPrice" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fix issue #220 : PriceFilter @change event is triggered before v-model updates the value