### PR TITLE
Product Attributes order -> Use MENU_ORDER

### DIFF
--- a/woonuxt_base/app/queries/getProduct.gql
+++ b/woonuxt_base/app/queries/getProduct.gql
@@ -24,7 +24,7 @@ query getProduct($slug: ID!) {
         scope
         ... on GlobalProductAttribute {
           slug
-          terms(where: {orderby: TERM_ORDER, order: ASC}) {
+          terms(where: {orderby: MENU_ORDER, order: ASC}) {
             nodes {
               name
               slug


### PR DESCRIPTION
Since the release of [WP GraphQL Woocommerce 0.21.0](https://github.com/wp-graphql/wp-graphql-woocommerce/releases/tag/v0.21.0)

We can use the sort order for product attributes (terms)-> `MENU_ORDER`.
Which means that the product attributes order can be used.

Check the video for more info:

https://github.com/user-attachments/assets/98947b17-008c-44a6-9212-3a8e7b0da194

Requires WP_GraphQL version 0.21.0