### PR TITLE
Fix attribute selection show relevant image

### DIFF
--- a/woonuxt_base/app/queries/fragments/ImageFragment.gql
+++ b/woonuxt_base/app/queries/fragments/ImageFragment.gql
@@ -2,4 +2,5 @@ fragment Image on MediaItem {
   sourceUrl
   altText
   title
+  databaseId
 }


### PR DESCRIPTION
DatabaseId is needed in Image to show the relevant variation image on attribute selection.
From a recent refactor the databaseId was removed.
So this piece of code broke here:
https://github.com/scottyzen/woonuxt/blob/master/woonuxt_base/app/components/productElements/ProductImageGallery.vue#L33

Another option would be to check with the sourceUrl like this
`const foundImage = galleryImages.value.find((img) => img.sourceUrl === newVal.image?.sourceUrl);`

WDYT @scottyzen  ?
