### PR TITLE
Fix SeoHead seo OpenGraph images

### DIFF
--- a/woonuxt_base/app/components/generalElements/SEOHead.vue
+++ b/woonuxt_base/app/components/generalElements/SEOHead.vue
@@ -9,13 +9,16 @@ const siteName = process.env.SITE_TITLE ?? 'WooNuxt';
 
 const img = useImage();
 const imageURL = info.image?.sourceUrl ?? '/images/placeholder.jpg';
+const defaultImageSrc = img.getSizes(imageURL, { width: 1200, height: 630 }).src;
+const twitterImageSrc = img.getSizes(imageURL, { width: 1600, height: 900 }).src;
+
 const getFullImageURL = (url: string) => {
   if (url.startsWith('http')) return url;
   return `${frontEndUrl}${url}`;
 };
-const fullImageURL = getFullImageURL(imageURL);
-const defaultImage = img.getSizes(fullImageURL, { width: 1200, height: 630 }).src;
-const twitterImageSrc = img.getSizes(fullImageURL, { width: 1600, height: 900 }).src;
+
+const defaultImage = getFullImageURL(defaultImageSrc);
+const twitterImage = getFullImageURL(twitterImageSrc);
 const description = info.shortDescription || info.description ? stripHtml(info.shortDescription || '') : stripHtml(info.description || '');
 
 const facebook = wooNuxtSEO?.find((item) => item.provider === 'facebook') ?? null;
@@ -37,7 +40,7 @@ const twitter = wooNuxtSEO?.find((item) => item.provider === 'twitter') ?? null;
     <Meta v-if="twitter?.handle" name="twitter:site" hid="twitter:site" :content="twitter.handle" />
     <Meta v-if="info.name" name="twitter:title" hid="twitter:title" :content="info.name" />
     <Meta v-if="description" name="twitter:description" hid="twitter:description" :content="description" />
-    <Meta name="twitter:image" hid="twitter:image" :content="twitterImageSrc" />
+    <Meta name="twitter:image" hid="twitter:image" :content="twitterImage" />
     <Meta name="twitter:url" hid="twitter:url" :content="canonical" />
     <Link rel="canonical" hid="canonical" :href="canonical" />
   </Head>

--- a/woonuxt_base/app/components/generalElements/SEOHead.vue
+++ b/woonuxt_base/app/components/generalElements/SEOHead.vue
@@ -8,11 +8,15 @@ const canonical = `${frontEndUrl}${path}`;
 const siteName = process.env.SITE_TITLE ?? 'WooNuxt';
 
 const img = useImage();
-const imagePrefix = isDev ? '' : frontEndUrl;
 const imageURL = info.image?.sourceUrl ?? '/images/placeholder.jpg';
-const defaultImage = imagePrefix + img.getSizes(imageURL, { width: 1200, height: 630 }).src;
-const twitterImageSrc = imagePrefix + img.getSizes(imageURL, { width: 1600, height: 900 }).src;
-const description = info.shortDescription || info.description ? stripHtml(info.shortDescription) : stripHtml(info.description);
+const getFullImageURL = (url: string) => {
+  if (url.startsWith('http')) return url;
+  return `${frontEndUrl}${url}`;
+};
+const fullImageURL = getFullImageURL(imageURL);
+const defaultImage = img.getSizes(fullImageURL, { width: 1200, height: 630 }).src;
+const twitterImageSrc = img.getSizes(fullImageURL, { width: 1600, height: 900 }).src;
+const description = info.shortDescription || info.description ? stripHtml(info.shortDescription || '') : stripHtml(info.description || '');
 
 const facebook = wooNuxtSEO?.find((item) => item.provider === 'facebook') ?? null;
 const twitter = wooNuxtSEO?.find((item) => item.provider === 'twitter') ?? null;


### PR DESCRIPTION
[Product page](https://v3.woonuxt.com/product/woo-logo-3) on Netlify og:image url:
`https://v3.woonuxt.com/.netlify/images?url=https:%2F%2Fsecure.woonuxt.com%2Fwp-content%2Fuploads%2F2021%2F10%2FT_1_front.jpg`
WORKS

[Product page](https://woonuxt-v3.vercel.app/product/woo-logo-3) on Vercel og:image url:
`https://v3.woonuxt.com/_vercel/image?url=https://secure.woonuxt.com/wp-content/uploads/2021/10/T_1_front.jpg&w=1536&q=100`
404

[[Product page](https://woo.nuxt.dev/product/woo-logo-3) on NuxtHub og:image url:
`https://v3.woonuxt.com/_ipx/_/https://secure.woonuxt.com/wp-content/uploads/2021/10/T_1_front.jpg`
404

[[My eshop Product](https://comewithreverse.com/product/guitar-practice-routine) on Cloudflare og:image url:
`https://comewithreverse.comhttps://comewithreverse.com/product/guitar-practice-routine`
404


In This PR I am checking if the url already starts with 'http', then we should not add the frontend url prefix.

I dont quite understand how these url's are generated. As far as I understand I'ts a way to leverage netlify and vercel cdn cache with image generation.
Currently I think this only works for Netlify. Could you elaborate how someone could use this on other deployments? like in cloudflare or vercel? 
