### PR TITLE
Add APP_HOST env for origin header

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 GQL_HOST="https://example.com/graphql"
 # If you have the WooNuxt-Settings plugin installed this is all you need. Everything else is optional and can be configured in the WordPress admin under Settings > WooNuxt. 
 
+# url of the app (optional, defaults to http://localhost:3000)
+APP_HOST="http://localhost:3000"
 
 # If you don't have the plugin installed, you can configure the rest of the settings here.
 

--- a/woonuxt_base/nuxt.config.ts
+++ b/woonuxt_base/nuxt.config.ts
@@ -37,6 +37,7 @@ export default defineNuxtConfig({
       default: {
         host: process.env.GQL_HOST || 'http://localhost:4000/graphql',
         corsOptions: { mode: 'cors', credentials: 'include' },
+        headers: { 'Origin': process.env.APP_HOST || 'http://localhost:3000' },
       },
     },
   },


### PR DESCRIPTION
This pull request introduces a new environment variable, APP_HOST, to the Nuxt.js configuration file (nuxt.config.ts 'graphql-client'  headers). The purpose of this addition is to ensure that requests made by the application include the correct Origin header, which is crucial for domain authorization and preventing unauthorized domains from accessing the server.

Changes Made
Environment Variable Addition:
Added APP_HOST to the .env.example file to specify the application's host server.
Updated the nuxt.config.ts file to use process.env.APP_HOST as the Origin header in the GraphQL client configuration.