### PR TITLE
fix/shippingMethodSelection

### DIFF
--- a/woonuxt_base/app/composables/useCheckout.ts
+++ b/woonuxt_base/app/composables/useCheckout.ts
@@ -54,18 +54,19 @@ export function useCheckout() {
     const { customer, loginUser } = useAuth();
     const router = useRouter();
     const { replaceQueryParam } = useHelpers();
-    const { emptyCart, refreshCart } = useCart();
+    const { cart, emptyCart, refreshCart } = useCart();
 
     isProcessingOrder.value = true;
 
     const { username, password, shipToDifferentAddress } = orderInput.value;
     const billing = customer.value?.billing;
     const shipping = shipToDifferentAddress ? customer.value?.shipping : billing;
-
+    const selectedMethod = cart.value?.chosenShippingMethods;
     try {
       let checkoutPayload: CheckoutInput = {
         billing,
         shipping,
+        shippingMethod: selectedMethod,
         metaData: orderInput.value.metaData,
         paymentMethod: orderInput.value.paymentMethod.id,
         customerNote: orderInput.value.customerNote,
@@ -73,10 +74,12 @@ export function useCheckout() {
         transactionId: orderInput.value.transactionId,
         isPaid,
       };
-
       // Create account
       if (orderInput.value.createAccount) {
         checkoutPayload.account = { username, password } as CreateAccountInput;
+      } else {
+        // Remove account from checkoutPayload if not creating account otherwise it will create an account anyway
+        checkoutPayload.account = null;
       }
 
       const { checkout } = await GqlCheckout(checkoutPayload);
@@ -94,15 +97,18 @@ export function useCheckout() {
       // PayPal redirect
       if ((await checkout?.redirect) && isPayPal) {
         const frontEndUrl = window.location.origin;
+        console.warn('[useCheckout.ts] proccessCheckout -> frontEndUrl', frontEndUrl);
         let redirectUrl = checkout?.redirect ?? '';
-
+        console.warn('[useCheckout.ts] proccessCheckout -> redirectUrl', redirectUrl);
         const payPalReturnUrl = `${frontEndUrl}/checkout/order-received/${orderId}/?key=${orderKey}&from_paypal=true`;
+        console.warn("[useCheckout.ts] proccessCheckout -> payPalReturnUrl", payPalReturnUrl);
         const payPalCancelUrl = `${frontEndUrl}/checkout/?cancel_order=true&from_paypal=true`;
+        console.warn("[useCheckout.ts] proccessCheckout -> payPalCancelUrl", payPalCancelUrl);
 
         redirectUrl = replaceQueryParam('return', payPalReturnUrl, redirectUrl);
         redirectUrl = replaceQueryParam('cancel_return', payPalCancelUrl, redirectUrl);
         redirectUrl = replaceQueryParam('bn', 'WooNuxt_Cart', redirectUrl);
-
+        console.warn('[useCheckout.ts] proccessCheckout -> redirectUrl', redirectUrl);
         const isPayPalWindowClosed = await openPayPalWindow(redirectUrl);
 
         if (isPayPalWindowClosed) {

--- a/woonuxt_base/app/composables/useCheckout.ts
+++ b/woonuxt_base/app/composables/useCheckout.ts
@@ -97,18 +97,14 @@ export function useCheckout() {
       // PayPal redirect
       if ((await checkout?.redirect) && isPayPal) {
         const frontEndUrl = window.location.origin;
-        console.warn('[useCheckout.ts] proccessCheckout -> frontEndUrl', frontEndUrl);
         let redirectUrl = checkout?.redirect ?? '';
-        console.warn('[useCheckout.ts] proccessCheckout -> redirectUrl', redirectUrl);
         const payPalReturnUrl = `${frontEndUrl}/checkout/order-received/${orderId}/?key=${orderKey}&from_paypal=true`;
-        console.warn("[useCheckout.ts] proccessCheckout -> payPalReturnUrl", payPalReturnUrl);
         const payPalCancelUrl = `${frontEndUrl}/checkout/?cancel_order=true&from_paypal=true`;
-        console.warn("[useCheckout.ts] proccessCheckout -> payPalCancelUrl", payPalCancelUrl);
 
         redirectUrl = replaceQueryParam('return', payPalReturnUrl, redirectUrl);
         redirectUrl = replaceQueryParam('cancel_return', payPalCancelUrl, redirectUrl);
         redirectUrl = replaceQueryParam('bn', 'WooNuxt_Cart', redirectUrl);
-        console.warn('[useCheckout.ts] proccessCheckout -> redirectUrl', redirectUrl);
+        
         const isPayPalWindowClosed = await openPayPalWindow(redirectUrl);
 
         if (isPayPalWindowClosed) {


### PR DESCRIPTION
# 🚀 Fix: The shipping method was reset at Guest Checkout

## 📝 Description
This update ensures that the selected **Shipping Method** (`shippingMethod`) is correctly passed to the `checkoutPayload`. Previously, WooCommerce did not recognize the shipping method during the checkout process, causing potential issues.

## 🔧 Changes
- **Added `shippingMethod` to `checkoutPayload`**
  - `chosenShippingMethods` from the `cart` is now properly included in the `checkoutPayload`.

## 🛠 Affected File(s)
- `useCheckout.ts`

## 📌 Relevant Code Snippet
```ts
const { cart, emptyCart, refreshCart } = useCart();
const selectedMethod = cart.value?.chosenShippingMethods;

let checkoutPayload: CheckoutInput = {
  billing,
  shipping,
  shippingMethod: selectedMethod, // ✅ Shipping method is now included
  metaData: orderInput.value.metaData,
  paymentMethod: orderInput.value.paymentMethod.id,
  customerNote: orderInput.value.customerNote,
  shipToDifferentAddress,
  transactionId: orderInput.value.transactionId,
  isPaid,
};

