### PR TITLE
Add orderby in Terms product order

### DIFF
--- a/woonuxt_base/app/queries/getProduct.gql
+++ b/woonuxt_base/app/queries/getProduct.gql
@@ -55,7 +55,7 @@ fragment ProductAttribute on ProductAttribute {
   label
   scope
   ... on GlobalProductAttribute {
-    terms {
+    terms(where: { orderby: MENU_ORDER, order: ASC }) {
       nodes {
         name
         slug


### PR DESCRIPTION
After the latest [PR](https://github.com/scottyzen/woonuxt/pull/285) the terms order is removed.
This change brings back the ability to use terms order like it was done in this [PR](https://github.com/scottyzen/woonuxt/pull/228)