### PR TITLE
fix space show: If displaying Euro currency, spaces will be incorrect…

### DIFF
--- a/woonuxt_base/app/components/OrderList.vue
+++ b/woonuxt_base/app/components/OrderList.vue
@@ -33,7 +33,7 @@ const goToOrder = (orderNumber: string): void => {
             <td class="rounded-l-lg">{{ order.orderNumber }}</td>
             <td>{{ formatDate(order.date) }}</td>
             <td><OrderStatusLabel v-if="order.status" :order="order" /></td>
-            <td class="text-right rounded-r-lg">{{ order.total }}</td>
+            <td class="text-right rounded-r-lg" v-html="order.total"></td>
           </tr>
         </tbody>
       </table>

--- a/woonuxt_base/app/pages/order-summary.vue
+++ b/woonuxt_base/app/pages/order-summary.vue
@@ -157,24 +157,24 @@ useSeoMeta({
         <div>
           <div class="flex justify-between">
             <span>{{ $t('messages.shop.subtotal') }}</span>
-            <span>{{ order.subtotal }}</span>
+            <span v-html="order.subtotal"></span>
           </div>
           <div class="flex justify-between">
             <span>{{ $t('messages.general.tax') }}</span>
-            <span>{{ order.totalTax }}</span>
+            <span v-html="order.totalTax"></span>
           </div>
           <div class="flex justify-between">
             <span>{{ $t('messages.general.shipping') }}</span>
-            <span>{{ order.shippingTotal }}</span>
+            <span v-html="order.shippingTotal"></span>
           </div>
           <div v-if="hasDiscount" class="flex justify-between text-primary">
             <span>{{ $t('messages.shop.discount') }}</span>
-            <span>- {{ order.discountTotal }}</span>
+            <span>- <span v-html="order.discountTotal"></span></span>
           </div>
           <hr class="my-8" />
           <div class="flex justify-between">
             <span class>{{ $t('messages.shop.total') }}</span>
-            <span class="font-semibold">{{ order.total }}</span>
+            <span class="font-semibold" v-html="order.total"></span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### fix space show
If displaying Euro currency, spaces will be incorrectly displayed as `&nbsp;`, for example, `100,00 €` will show `100,00&nbsp;€`

![微信截图_20250717194047](https://github.com/user-attachments/assets/46a0a205-46c6-4109-90f4-0bc8ef60eba0)
![微信截图_20250717194114](https://github.com/user-attachments/assets/34c8ab77-e74d-4715-a021-b0a12cd3455a)
