### PR TITLE
fix space show: If displaying Euro currency, spaces will be incorrect…

### DIFF
--- a/woonuxt_base/app/components/shopElements/OrderSummary.vue
+++ b/woonuxt_base/app/components/shopElements/OrderSummary.vue
@@ -20,7 +20,7 @@ const { cart, isUpdatingCart } = useCart();
       <div class="flex justify-between">
         <span>{{ $t('messages.general.shipping') }}</span>
         <span class="text-gray-700 tabular-nums">
-          {{ parseFloat(cart.shippingTotal) > 0 ? '+' : '' }} {{ cart.shippingTotal }}
+          {{ parseFloat(cart.shippingTotal) > 0 ? '+' : '' }} <span v-html="cart.shippingTotal"></span>
         </span>
       </div>
       <Transition name="scale-y" mode="out-in">


### PR DESCRIPTION
### fix space show
If displaying Euro currency, spaces will be incorrectly displayed as `&nbsp;`, for example, `100,00 €` will show `100,00&nbsp;€`

[same fix](https://github.com/scottyzen/woonuxt/pull/310#issue-3239260376) for Newly discovered pages.

