### PR TITLE
chore: add .vscode config folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ logs
 .fleet
 .idea
 
+# vscode config
+.vscode
+
 # Local env files
 .env
 .env.*


### PR DESCRIPTION
Exclude the .vscode folder from version control to keep editor-specific settings out of the repository.