### PR TITLE
style: prevent product names that are too long from displaying incorr…

### DIFF
--- a/woonuxt_base/app/components/cartElements/CartCard.vue
+++ b/woonuxt_base/app/components/cartElements/CartCard.vue
@@ -41,7 +41,8 @@ const moveToWishList = () => {
       </NuxtLink>
       <div class="flex-1">
         <div class="flex gap-x-2 gap-y-1 flex-wrap items-center">
-          <NuxtLink class="leading-tight" :to="productSlug">{{ productType.name }}</NuxtLink>
+          <!-- 2025-6-4：line-clamp-2 is used to prevent product names that are too long from displaying incorrectly—on desktop in the checkout page and on mobile in the shopping cart. -->
+          <NuxtLink class="leading-tight line-clamp-2" :to="productSlug" :title="productType.name">{{ productType.name }}</NuxtLink>
           <span v-if="productType.salePrice" class="text-[10px] border-green-200 leading-none bg-green-100 inline-block p-0.5 rounded text-green-600 border">
             Save {{ salePercentage }}
           </span>


### PR DESCRIPTION
prevent product names that are too long from displaying incorrectly—on desktop in the checkout page and on mobile in the shopping cart.

Before:

<img width="1042" height="964" alt="ScreenShot_2025-11-28_203234_052" src="https://github.com/user-attachments/assets/b4fa0e54-f6cf-4db6-9604-5672fa6605e6" />

After:

<img width="1024" height="938" alt="ScreenShot_2025-11-29_174321_588" src="https://github.com/user-attachments/assets/758acd28-a3fa-4bfa-95b2-fdbd0dda36bb" />

