### PR TITLE
Attribute Selection Overhaul + Variation Matching Improvements

### DIFF
--- a/woonuxt_base/app/composables/useHelpers.ts
+++ b/woonuxt_base/app/composables/useHelpers.ts
@@ -21,33 +21,6 @@ export function useHelpers() {
   }
 
   /**
-   * Formats an array of variation objects by removing spaces and hyphens from the 'name' and 'value' properties.
-   * @param {VariationAttribute[]} arr - The array of variation objects to format. Each object should have 'name' and 'value' properties.
-   * @returns {VariationAttribute[]} The formatted array of variation objects.
-   */
-  const formatVariationArrays = (arr: VariationAttribute[]): VariationAttribute[] =>
-    arr.map((a) => ({ ...a, name: a.name?.replace(/[-\s]/g, '') || '', value: a.value?.replace(/[-\s]/g, '') || '' }));
-
-  /**
-   * Determines if two arrays of variations are equal by comparing the formatted arrays.
-   * @param {VariationAttribute[]} a1 - The first array of variations to compare.
-   * @param {VariationAttribute[]} a2 - The second array of variations to compare.
-   * @returns {boolean} True if the arrays are equal, false otherwise.
-   */
-  const arraysEqual = (a1: VariationAttribute[], a2: VariationAttribute[]): boolean =>
-    JSON.stringify(formatVariationArrays(a1)) === JSON.stringify(formatVariationArrays(a2));
-
-  // Formats an array of variations by converting the name and value properties to lowercase.
-  const formatArray = (arr: VariationAttribute[]): Array<{ name: string; value: string }> => {
-    return arr.map((v) => {
-      let name = v.name?.toLowerCase() || '';
-      name = name.startsWith('pa_') ? name.replace('pa_', '') : name;
-      const value = v.value?.toLowerCase() || '';
-      return { name, value };
-    });
-  };
-
-  /**
    * Clears all cookies.
    */
   function clearAllCookies(): void {
@@ -105,28 +78,6 @@ export function useHelpers() {
     const body = document.querySelector('body');
     body?.classList.contains(className) ? body.classList.remove(className) : body?.classList.add(className);
   }
-
-  /**
-   * Checks for variation type of 'any' and returns an array of the indexes of those variations.
-   * @param {Product} product - The product to check.
-   * @returns {number[]} An array of the indexes of variations with a type of 'any'.
-   */
-  const checkForVariationTypeOfAny = (product: Product): number[] => {
-    const numberOfVariation = product?.attributes?.nodes?.length ?? 0;
-    let indexOfTypeAny = [] as number[];
-
-    for (let index = 0; index < numberOfVariation; index++) {
-      const tempArray = [] as string[];
-      product?.variations?.nodes?.forEach((element) => {
-        const value = element.attributes?.nodes[index]?.value;
-        if (typeof value === 'string') tempArray.push(value);
-      });
-
-      if (!tempArray.some(Boolean)) indexOfTypeAny.push(index);
-    }
-
-    return indexOfTypeAny;
-  };
 
   /**
    * Determines if the route query is empty.
@@ -250,8 +201,6 @@ export function useHelpers() {
     isDev,
     checkGraphQLExtensions,
     FALLBACK_IMG,
-    formatArray,
-    arraysEqual,
     clearAllCookies,
     clearAllLocalStorage,
     replaceQueryParam,
@@ -259,7 +208,6 @@ export function useHelpers() {
     removeBodyClass,
     toggleBodyClass,
     toggleMobileMenu,
-    checkForVariationTypeOfAny,
     formatDate,
     formatPrice,
     scrollToTop,


### PR DESCRIPTION
This pull request significantly refactors the `AttributeSelections.vue` component to provide a more robust, user-friendly, and maintainable product attribute selection experience. The main changes include replacing the legacy DOM-based attribute selection logic with a reactive, model-driven approach, improving UI feedback for unavailable options, and centralizing attribute selection logic within the component. Additionally, unused and redundant helper functions have been removed from `useHelpers.ts`, resulting in a cleaner codebase.

**Major refactor and logic improvements for attribute selection:**

* Replaced the old DOM-query-based attribute selection (`activeVariations`, `updateAttrs`, etc.) with a new reactive `selections` model, computed properties, and utility functions for normalization and matching. This enables more accurate and maintainable handling of attribute combinations and variation availability.
* Added logic to compute which options are enabled/disabled (`isOptionEnabled`) based on available variations, and to resolve invalid or incomplete selections automatically. This ensures users can only select valid attribute combinations and improves the overall UX.

**UI/UX enhancements:**

* Updated the template to bind inputs directly to the new `selections` model using `v-model`, display disabled states for unavailable options, and provide contextual hints to guide users through attribute selection. [[1]](diffhunk://#diff-0ad467d2e9b5eeaa984735a40f580bbb8dbeea90be8adcd34341cc952a9a4f3dL59-R340) [[2]](diffhunk://#diff-0ad467d2e9b5eeaa984735a40f580bbb8dbeea90be8adcd34341cc952a9a4f3dL86-R372) [[3]](diffhunk://#diff-0ad467d2e9b5eeaa984735a40f580bbb8dbeea90be8adcd34341cc952a9a4f3dL112-R432)
* Added styles for disabled radio and color buttons to visually indicate unavailable options.

These changes make attribute selection more reliable, maintainable, and user-friendly, while reducing technical debt in the codebase.

# Before

https://github.com/user-attachments/assets/ecf575d7-492c-4677-b97e-9316055568aa

#After

https://github.com/user-attachments/assets/9c197e45-c2af-4739-8c02-3d9c221334d2



