### PR TITLE
fix graphql auth hook and login session typing

### DIFF
--- a/woonuxt_base/app/composables/useAuth.ts
+++ b/woonuxt_base/app/composables/useAuth.ts
@@ -4,6 +4,7 @@ import type {
   CreateAccountInput,
   Customer,
   DownloadableItem,
+  LoginSession,
   LoginClient,
   LoginInput,
   Order,
@@ -84,7 +85,7 @@ export const useAuth = () => {
     viewer.value = null;
   };
 
-  const applyLoginSession = async (payload?: { authToken?: string | null; refreshToken?: string | null }): Promise<boolean> => {
+  const applyLoginSession = async (payload?: LoginSession | null): Promise<boolean> => {
     if (!payload?.authToken) return false;
     setAuthSessionFromLogin(payload);
     await refreshCart();

--- a/woonuxt_base/app/composables/useAuthTokens.ts
+++ b/woonuxt_base/app/composables/useAuthTokens.ts
@@ -1,3 +1,5 @@
+import type { LoginSession } from '#types/gql';
+
 const REFRESH_TOKEN_COOKIE = 'auth-refresh-token';
 const LEGACY_GQL_TOKEN_COOKIE = 'gql:default';
 const REFRESH_BUFFER_SECONDS = 60;
@@ -53,7 +55,7 @@ export const useAuthTokens = () => {
     refreshToken.value = null;
   };
 
-  const setAuthSessionFromLogin = (payload?: { authToken?: string | null; refreshToken?: string | null }): void => {
+  const setAuthSessionFromLogin = (payload?: LoginSession | null): void => {
     if (!payload?.authToken) return;
     refreshToken.value = payload.refreshToken ?? null;
     setActiveAuthToken(payload.authToken);

--- a/woonuxt_base/app/plugins/gql-auth.ts
+++ b/woonuxt_base/app/plugins/gql-auth.ts
@@ -1,6 +1,7 @@
 export default defineNuxtPlugin((nuxtApp) => {
+  const { getAuthTokenForRequest } = useAuthTokens();
+
   nuxtApp.hook('gql:auth:init', async ({ token }) => {
-    const { getAuthTokenForRequest } = useAuthTokens();
     token.value = (await getAuthTokenForRequest()) ?? undefined;
   });
 });

--- a/woonuxt_base/app/types/gql.ts
+++ b/woonuxt_base/app/types/gql.ts
@@ -24,6 +24,8 @@ import type {
   CommentFragment,
   ProductAttributeFragment,
   LoginClientFragment,
+  LoginMutation,
+  LoginWithProviderMutation,
 } from '#gql';
 import type { StockStatusEnum } from '#gql/default';
 
@@ -106,6 +108,7 @@ export type VariationAttribute = VariationAttributeFragment;
 export type Comment = CommentFragment;
 export type ProductAttribute = ProductAttributeFragment;
 export type LoginClient = LoginClientFragment;
+export type LoginSession = NonNullable<LoginMutation['login']> | NonNullable<LoginWithProviderMutation['login']>;
 
 export interface ProductAttributeInput {
   attributeName: string;

--- a/woonuxt_base/nuxt.config.ts
+++ b/woonuxt_base/nuxt.config.ts
@@ -22,7 +22,7 @@ export default defineNuxtConfig({
     pageTransition: { name: 'page', mode: 'default' },
   },
 
-  plugins: [resolve('./app/plugins/gql-auth.client.ts'), resolve('./app/plugins/init.ts')],
+  plugins: [resolve('./app/plugins/gql-auth.ts'), resolve('./app/plugins/init.ts')],
 
   components: [{ path: resolve('./app/components'), pathPrefix: false }],
 


### PR DESCRIPTION

- Replace the client-only gql auth plugin with a universal plugin so auth init can run during SSR.
- Align login session handling with generated GraphQL operation types to avoid wrapper type mismatches.