### PR TITLE
Pluginize payment gateways

### DIFF
--- a/woonuxt_base/app/components/payments/PaymentGatewayComponent.vue
+++ b/woonuxt_base/app/components/payments/PaymentGatewayComponent.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import type { PaymentGateway } from '#types/gql';
+
+const props = defineProps<{
+  gateway?: PaymentGateway | string | null;
+}>();
+
+const { getGateway } = usePaymentGateways();
+
+const gatewayId = computed(() => (typeof props.gateway === 'string' ? props.gateway : (props.gateway?.id ?? '')));
+const gatewayPlugin = computed(() => getGateway(gatewayId.value));
+const componentProps = computed(() => gatewayPlugin.value?.getComponentProps?.() ?? {});
+const componentEvents = computed(() => gatewayPlugin.value?.getComponentEvents?.() ?? {});
+</script>
+
+<template>
+  <component :is="gatewayPlugin.component" v-if="gatewayPlugin?.component" v-bind="componentProps" v-on="componentEvents" />
+</template>

--- a/woonuxt_base/app/components/payments/StripePaymentGateway.vue
+++ b/woonuxt_base/app/components/payments/StripePaymentGateway.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import type { Stripe } from '@stripe/stripe-js';
+
+const props = defineProps<{
+  stripe: Stripe | null;
+  clientSecret?: string | null;
+  customerId?: string | null;
+  amount?: number | null;
+  currency?: string | null;
+  canSavePaymentMethod?: boolean;
+  savePaymentMethod?: boolean;
+  shouldShowStripeElement?: boolean;
+}>();
+
+const emit = defineEmits<{
+  updateElement: [element: unknown];
+  updateSavePaymentMethod: [value: boolean];
+}>();
+
+const isStripeElementVisible = computed(() => !!props.stripe && props.shouldShowStripeElement);
+const shouldShowSavePaymentMethod = computed(() => isStripeElementVisible.value && !!props.canSavePaymentMethod);
+const saveForFuture = computed({
+  get: () => !!props.savePaymentMethod,
+  set: (value: boolean) => emit('updateSavePaymentMethod', value),
+});
+</script>
+
+<template>
+  <div>
+    <StripeElement
+      v-if="isStripeElementVisible && stripe"
+      :stripe
+      :client-secret="clientSecret"
+      :customer-id="customerId"
+      :amount="amount"
+      :currency="currency"
+      :save-for-future="canSavePaymentMethod && saveForFuture"
+      @update-element="(element) => emit('updateElement', element)" />
+
+    <div v-if="shouldShowSavePaymentMethod" class="mt-3 flex items-start gap-2">
+      <input
+        id="save-payment-method"
+        v-model="saveForFuture"
+        type="checkbox"
+        name="save-payment-method"
+        class="mt-0.5 h-4 w-4 rounded-sm border-gray-300 bg-white text-primary focus:ring-3 focus:ring-primary" />
+      <label for="save-payment-method" class="text-sm font-medium text-gray-700"> Save payment information to my account for future purchases. </label>
+    </div>
+  </div>
+</template>

--- a/woonuxt_base/app/components/shopElements/PaymentOptions.vue
+++ b/woonuxt_base/app/components/shopElements/PaymentOptions.vue
@@ -1,65 +1,66 @@
 <script setup lang="ts">
 import type { PaymentGateway, PaymentGateways } from '#types/gql';
-
-export type SavedPaymentMethod = {
-  id: number;
-  token: string;
-  customerId?: string | null;
-  last4: string;
-  expiryMonth: string;
-  expiryYear: string;
-  cardType: string;
-  isDefault: boolean;
-};
+import type { PaymentGatewayOption } from '#types/payment-gateway-plugin';
 
 const props = defineProps<{
   modelValue: string | object;
   paymentGateways: PaymentGateways;
-  savedPaymentMethods?: SavedPaymentMethod[];
-  selectedSavedPaymentMethod?: SavedPaymentMethod | null;
 }>();
 
 const paymentMethod = toRef(props, 'modelValue');
 const emits = defineEmits<{
   'update:modelValue': [gateway: PaymentGateway];
-  'update:selectedSavedPaymentMethod': [method: SavedPaymentMethod | null];
 }>();
 const gateways = computed<PaymentGateway[]>(() => props.paymentGateways?.nodes || []);
-const savedMethods = computed<SavedPaymentMethod[]>(() => props.savedPaymentMethods || []);
+const { getGateway } = usePaymentGateways();
 
 const selectedGatewayId = computed<string>(() => {
   const value = paymentMethod.value as PaymentGateway | string | null | undefined;
   return (typeof value === 'string' ? value : value?.id) || gateways.value[0]?.id || '';
 });
 
-const activePaymentMethod = computed<PaymentGateway | null>(() => {
-  return gateways.value.find((gateway) => gateway.id === selectedGatewayId.value) || null;
+const defaultGatewayOption = (gateway: PaymentGateway): PaymentGatewayOption => {
+  const plugin = getGateway(gateway.id);
+  const pluginIcon = plugin?.icon;
+  const icon = typeof pluginIcon === 'function' ? pluginIcon(gateway) : pluginIcon || gateway.icon || null;
+
+  return {
+    id: gateway.id,
+    gateway,
+    title: gateway.title || plugin?.name || 'Payment Method',
+    description: gateway.description,
+    icon,
+    iconName: plugin?.iconName || 'ion:cash-outline',
+  };
+};
+
+const paymentOptions = computed<PaymentGatewayOption[]>(() => {
+  return gateways.value
+    .flatMap((gateway, gatewayIndex) => {
+      const options = getGateway(gateway.id)?.getPaymentOptions?.(gateway) ?? [defaultGatewayOption(gateway)];
+      return options.map((option, optionIndex) => ({
+        ...option,
+        sortOrder: option.sortOrder ?? gatewayIndex * 100 + optionIndex,
+      }));
+    })
+    .sort((first, second) => (first.sortOrder ?? 0) - (second.sortOrder ?? 0));
 });
 
-const normalizedCardBrand = (cardType?: string | null): string => {
-  const brand = cardType?.toLowerCase().replace(/[\s_-]/g, '') || '';
-  if (brand.includes('visa')) return 'visa';
-  if (brand.includes('master')) return 'mastercard';
-  return 'card';
+const activePaymentOption = computed<PaymentGatewayOption | null>(() => paymentOptions.value.find((option) => isOptionSelected(option)) || null);
+const selectedOptionId = computed<string>(() => {
+  const explicitlySelectedOption = paymentOptions.value.find((option) => option.isSelected);
+  if (explicitlySelectedOption) return explicitlySelectedOption.id;
+
+  return paymentOptions.value.find((option) => option.gateway.id === selectedGatewayId.value)?.id ?? '';
+});
+
+const isOptionSelected = (option: PaymentGatewayOption): boolean => {
+  return option.id === selectedOptionId.value;
 };
 
-const cardBrandIcon = (cardType?: string | null): string | null => {
-  const brand = normalizedCardBrand(cardType);
-  return brand === 'card' ? null : `/icons/payment/${brand}.svg`;
-};
-
-const gatewayIcon = (gateway: PaymentGateway): string | null => {
-  if (gateway.id === 'paypal') return '/icons/payment/paypal.svg';
-  return gateway.icon || null;
-};
-
-const updatePaymentMethod = (gateway: PaymentGateway) => {
-  emits('update:selectedSavedPaymentMethod', null);
-  emits('update:modelValue', gateway);
-};
-
-const updateSavedPaymentMethod = (method: SavedPaymentMethod) => {
-  emits('update:selectedSavedPaymentMethod', method);
+const updatePaymentMethod = async (option: PaymentGatewayOption) => {
+  await option.onSelect?.();
+  emits('update:modelValue', option.gateway);
 };
 
 watch(
@@ -71,7 +72,7 @@ watch(
     const currentId = typeof value === 'string' ? value : value?.id;
 
     if (typeof value === 'object' && value && currentId === matchedGateway.id) return;
-    updatePaymentMethod(matchedGateway);
+    emits('update:modelValue', matchedGateway);
   },
   { immediate: true },
 );
@@ -81,84 +82,45 @@ watch(
   <div class="w-full">
     <div class="grid gap-3" role="radiogroup" aria-label="Payment options">
       <button
-        v-for="method in savedMethods"
-        :key="method.id"
+        v-for="option in paymentOptions"
+        :key="option.id"
         type="button"
         class="flex w-full items-center justify-between gap-3 rounded-lg border bg-white px-4 py-3 text-left text-sm font-medium text-gray-900 transition-colors hover:border-primary hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-        :class="selectedSavedPaymentMethod?.id === method.id ? 'border-primary' : 'border-gray-300'"
+        :class="isOptionSelected(option) ? 'border-primary' : 'border-gray-300'"
         role="radio"
-        :aria-checked="selectedSavedPaymentMethod?.id === method.id"
-        :title="`${method.cardType} ending in ${method.last4}`"
-        @click="updateSavedPaymentMethod(method)">
+        :aria-checked="isOptionSelected(option)"
+        :title="option.description || option.title || 'Payment Method'"
+        @click="updatePaymentMethod(option)">
         <span class="flex min-w-0 flex-1 items-center gap-3">
           <span class="grid h-6 w-6 flex-none place-items-center" aria-hidden="true">
             <NuxtImg
-              v-if="cardBrandIcon(method.cardType)"
-              :src="cardBrandIcon(method.cardType)!"
-              :alt="method.cardType"
-              width="28"
-              height="20"
-              class="h-5 w-6 object-contain"
-              fit="contain"
-              loading="lazy" />
-            <icon v-else name="ion:card-outline" size="22" class="text-gray-600" />
-          </span>
-          <span class="flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1 leading-tight">
-            <span class="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-1">
-              <span class="text-base font-semibold capitalize">{{ method.cardType }}</span>
-              <span class="text-base font-semibold text-gray-500">•••• {{ method.last4 }}</span>
-            </span>
-            <span class="text-base font-medium text-gray-500">expires {{ method.expiryMonth }}/{{ method.expiryYear }}</span>
-          </span>
-          <span v-if="method.isDefault" class="ml-auto hidden flex-none text-xs font-semibold text-primary sm:inline">Default</span>
-        </span>
-        <span
-          class="grid h-4 w-4 flex-none place-items-center rounded-full border transition-colors"
-          :class="selectedSavedPaymentMethod?.id === method.id ? 'border-primary bg-primary' : 'border-gray-300 bg-white'"
-          aria-hidden="true">
-          <span class="h-2 w-2 rounded-full bg-white" :class="selectedSavedPaymentMethod?.id === method.id ? 'opacity-100' : 'opacity-0'"></span>
-        </span>
-      </button>
-
-      <button
-        v-for="gateway in gateways"
-        :key="gateway.id"
-        type="button"
-        class="flex w-full items-center justify-between gap-3 rounded-lg border bg-white px-4 py-3 text-left text-sm font-medium text-gray-900 transition-colors hover:border-primary hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-        :class="!selectedSavedPaymentMethod && gateway.id === selectedGatewayId ? 'border-primary' : 'border-gray-300'"
-        role="radio"
-        :aria-checked="!selectedSavedPaymentMethod && gateway.id === selectedGatewayId"
-        :title="gateway?.description || gateway?.title || 'Payment Method'"
-        @click="updatePaymentMethod(gateway)">
-        <span class="flex min-w-0 flex-1 items-center gap-3">
-          <span class="grid h-6 w-6 flex-none place-items-center" aria-hidden="true">
-            <NuxtImg
-              v-if="gatewayIcon(gateway)"
-              :src="gatewayIcon(gateway)!"
-              :alt="gateway.title || 'Payment Method'"
+              v-if="option.icon"
+              :src="option.icon"
+              :alt="option.title || 'Payment Method'"
               width="28"
               height="24"
               class="h-5 w-6 object-contain"
               fit="contain"
               loading="lazy" />
-            <icon v-else-if="gateway.id === 'stripe'" name="ion:card-outline" size="22" class="text-gray-600" />
-            <icon v-else name="ion:cash-outline" size="22" class="text-gray-600" />
+            <icon v-else :name="option.iconName || 'ion:cash-outline'" size="22" class="text-gray-600" />
           </span>
-          <span class="min-w-0 truncate text-base font-semibold leading-tight" v-html="gateway.title"></span>
+          <span class="flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1 leading-tight">
+            <span class="min-w-0 text-base font-semibold" v-html="option.title"></span>
+            <span v-for="detail in option.details" :key="detail" class="text-base font-semibold text-gray-500">{{ detail }}</span>
+          </span>
+          <span v-if="option.badge" class="ml-auto hidden flex-none text-xs font-semibold text-primary sm:inline">{{ option.badge }}</span>
         </span>
         <span
           class="grid h-4 w-4 flex-none place-items-center rounded-full border transition-colors"
-          :class="!selectedSavedPaymentMethod && gateway.id === selectedGatewayId ? 'border-primary bg-primary' : 'border-gray-300 bg-white'"
+          :class="isOptionSelected(option) ? 'border-primary bg-primary' : 'border-gray-300 bg-white'"
           aria-hidden="true">
-          <span
-            class="h-2 w-2 rounded-full bg-white"
-            :class="!selectedSavedPaymentMethod && gateway.id === selectedGatewayId ? 'opacity-100' : 'opacity-0'"></span>
+          <span class="h-2 w-2 rounded-full bg-white" :class="isOptionSelected(option) ? 'opacity-100' : 'opacity-0'"></span>
         </span>
       </button>
     </div>
 
-    <div v-if="!selectedSavedPaymentMethod && activePaymentMethod?.description" class="prose block w-full mt-3">
-      <p class="text-sm text-gray-500" v-html="activePaymentMethod.description"></p>
+    <div v-if="activePaymentOption?.description" class="prose block w-full mt-3">
+      <p class="text-sm text-gray-500" v-html="activePaymentOption.description"></p>
     </div>
   </div>
 </template>

--- a/woonuxt_base/app/components/shopElements/StripeElement.vue
+++ b/woonuxt_base/app/components/shopElements/StripeElement.vue
@@ -4,7 +4,6 @@ import type { Appearance, Stripe, StripeElements } from '@stripe/stripe-js';
 const props = defineProps<{
   stripe: Stripe;
   clientSecret?: string | null;
-  customerSessionClientSecret?: string | null;
   customerId?: string | null;
   amount?: number | null;
   currency?: string | null;
@@ -87,9 +86,6 @@ const createStripeElements = async () => {
       clientSecret: props.clientSecret,
       appearance: stripeAppearance.value,
     };
-    if (props.customerSessionClientSecret) {
-      elementsOptions.customerSessionClientSecret = props.customerSessionClientSecret;
-    }
     elements = props.stripe.elements(elementsOptions);
     elementsMode = 'intent';
   } else {
@@ -126,7 +122,7 @@ const createStripeElements = async () => {
 };
 
 watch(
-  () => [props.clientSecret, props.customerSessionClientSecret],
+  () => props.clientSecret,
   () => {
     if (!props.clientSecret && !canCreateDeferred.value) {
       resetStripeElements();
@@ -160,6 +156,10 @@ watch(canCreateDeferred, (canCreate) => {
 
 onMounted(() => {
   createStripeElements();
+});
+
+onUnmounted(() => {
+  resetStripeElements();
 });
 </script>
 

--- a/woonuxt_base/app/composables/usePaymentGateways.ts
+++ b/woonuxt_base/app/composables/usePaymentGateways.ts
@@ -1,0 +1,78 @@
+import type { PaymentGatewayPlugin, PaymentGatewayProcessResult } from '#types/payment-gateway-plugin';
+
+import type { PaymentGateway } from '#types/gql';
+import type { ShallowRef } from 'vue';
+
+type GatewayRegistryNuxtApp = ReturnType<typeof useNuxtApp> & {
+  _paymentGatewayPlugins?: ShallowRef<Map<string, PaymentGatewayPlugin>>;
+};
+
+export function usePaymentGateways() {
+  const nuxtApp = useNuxtApp() as GatewayRegistryNuxtApp;
+  nuxtApp._paymentGatewayPlugins ??= shallowRef(new Map<string, PaymentGatewayPlugin>());
+
+  const gatewayPlugins = nuxtApp._paymentGatewayPlugins;
+  const activeGatewayId = useState<string | null>('activePaymentGatewayId', () => null);
+
+  const registerGateway = (plugin: PaymentGatewayPlugin): void => {
+    if (!plugin.id) {
+      console.error('[usePaymentGateways] Cannot register a gateway without an id.');
+      return;
+    }
+
+    const nextPlugins = new Map(gatewayPlugins.value);
+    nextPlugins.set(plugin.id, plugin);
+    gatewayPlugins.value = nextPlugins;
+  };
+
+  const getGateway = (gatewayId?: string | null): PaymentGatewayPlugin | undefined => {
+    return gatewayId ? gatewayPlugins.value.get(gatewayId) : undefined;
+  };
+
+  const setActiveGateway = async (gateway?: PaymentGateway | string | null): Promise<void> => {
+    const nextGatewayId = typeof gateway === 'string' ? gateway : (gateway?.id ?? null);
+    if (activeGatewayId.value === nextGatewayId) return;
+
+    const previousGateway = getGateway(activeGatewayId.value);
+    if (previousGateway?.onDeselect) await previousGateway.onDeselect();
+
+    activeGatewayId.value = nextGatewayId;
+
+    const nextGateway = getGateway(nextGatewayId);
+    if (nextGateway?.onSelect) {
+      await nextGateway.onSelect(gateway);
+    }
+  };
+
+  const activeGateway = computed(() => getGateway(activeGatewayId.value));
+
+  const isActiveGatewayReady = computed<boolean>(() => {
+    const gateway = activeGateway.value;
+    return gateway?.isReady ? gateway.isReady() : true;
+  });
+
+  const getActiveGatewayDisabledMessage = (): string => {
+    const gateway = activeGateway.value;
+    return gateway?.getDisabledMessage?.() ?? '';
+  };
+
+  const resetActiveGateway = (): void => {
+    activeGateway.value?.reset?.();
+  };
+
+  const processActiveGatewayPayment = async (): Promise<PaymentGatewayProcessResult> => {
+    const gateway = activeGateway.value;
+    if (!gateway?.processPayment) return { success: true, isPaid: false };
+    return await gateway.processPayment();
+  };
+
+  return {
+    registerGateway,
+    getGateway,
+    setActiveGateway,
+    isActiveGatewayReady,
+    getActiveGatewayDisabledMessage,
+    resetActiveGateway,
+    processActiveGatewayPayment,
+  };
+}

--- a/woonuxt_base/app/pages/checkout.vue
+++ b/woonuxt_base/app/pages/checkout.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { loadStripe } from '@stripe/stripe-js';
-import type { Stripe, StripeElements } from '@stripe/stripe-js';
-import type { Viewer } from '#types/gql';
+import type { PaymentGateway } from '#types/gql';
+
 const route = useRoute();
 
 const { t } = useI18n();
@@ -9,148 +8,33 @@ const { query } = route;
 const { cart, paymentGateways, isBillingAddressEnabled } = useCart();
 const { customer, viewer, navigateToLogin } = useAuth();
 const { orderInput, isProcessingOrder, processCheckout, checkoutError, resolvePaymentMethodId } = useCheckout();
-const runtimeConfig = useRuntimeConfig();
-const stripeKey = runtimeConfig.public?.STRIPE_PUBLISHABLE_KEY || null;
+const { setActiveGateway, isActiveGatewayReady, processActiveGatewayPayment, getActiveGatewayDisabledMessage, resetActiveGateway } = usePaymentGateways();
 
 const buttonText = ref<string>(isProcessingOrder.value ? t('general.processing') : t('shop.checkoutButton'));
-const savePaymentMethod = ref<boolean>(false);
+const checkoutPaymentGateways = paymentGateways;
+const selectedPaymentMethodId = computed<string>(() => resolvePaymentMethodId(orderInput.value.paymentMethod));
 
-type SavedPaymentMethod = {
-  id: number;
-  token: string;
-  customerId?: string | null;
-  last4: string;
-  expiryMonth: string;
-  expiryYear: string;
-  cardType: string;
-  isDefault: boolean;
-};
+const isInvalidEmail = ref<boolean>(false);
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
 
-type CheckoutViewer = Viewer & {
-  stripeCustomerId?: string | null;
-  savedPaymentMethods?: SavedPaymentMethod[] | null;
+type CheckoutViewerSummary = {
   email?: string | null;
   firstName?: string | null;
   lastName?: string | null;
   databaseId?: number | null;
 };
-const viewerAsCheckoutViewer = computed<CheckoutViewer | null>(() => viewer.value as CheckoutViewer | null);
-const stripeCustomerId = computed<string | null>(() => viewerAsCheckoutViewer.value?.stripeCustomerId ?? null);
-const savedPaymentMethods = computed<SavedPaymentMethod[]>(() => viewerAsCheckoutViewer.value?.savedPaymentMethods ?? []);
-const selectedSavedToken = ref<SavedPaymentMethod | null>(null);
-const isCreatingAccountAtCheckout = computed<boolean>(() => !viewer.value && !!orderInput.value.createAccount);
-const canSavePaymentMethod = computed<boolean>(() => !!viewer.value || isCreatingAccountAtCheckout.value);
-const checkoutPaymentGateways = paymentGateways;
-const stripeGateway = computed(() => paymentGateways.value?.nodes.find((gateway) => gateway.id === 'stripe') ?? null);
 
-const activateStripeGateway = (): void => {
-  if (stripeGateway.value) {
-    orderInput.value.paymentMethod = stripeGateway.value;
-  }
-};
-
-const upsertOrderMeta = (key: string, value: string): void => {
-  const existingMeta = orderInput.value.metaData.find((entry: { key: string }) => entry.key === key);
-  if (existingMeta) {
-    existingMeta.value = value;
-    return;
-  }
-
-  orderInput.value.metaData.push({ key, value });
-};
-
-const resetStripeOrderMeta = (): void => {
-  const stripeMetaKeys = new Set([
-    '_stripe_payment_intent_id',
-    '_stripe_payment_method_id',
-    '_stripe_source_id',
-    '_stripe_fee',
-    '_stripe_net',
-    '_stripe_currency',
-    '_stripe_charge_captured',
-    '_wc_stripe_payment_method_type',
-    '_stripe_intent_id',
-  ]);
-
-  orderInput.value.metaData = orderInput.value.metaData.filter((entry: { key: string }) => !stripeMetaKeys.has(entry.key));
-};
-
-// Auto-select the default (or first) saved card when the viewer loads.
-watch(
-  savedPaymentMethods,
-  (methods) => {
-    if (methods.length > 0 && !selectedSavedToken.value) {
-      selectedSavedToken.value = methods.find((m) => m.isDefault) ?? methods[0]!;
-      activateStripeGateway();
-    }
-  },
-  { immediate: true },
-);
-
-/**
- * Keep Stripe active when a saved card is selected. Don't clear stripeClientSecret —
- * StripeElement is unmounted anyway (v-if), and preserving it avoids a round-trip
- * when switching back to "Use another payment method".
- */
-watch(selectedSavedToken, async (token, previousToken) => {
-  if (token) {
-    activateStripeGateway();
-    return;
-  }
-
-  // Fetch a PI only if we don't already have one.
-  if (previousToken && stripe && !stripeClientSecret.value) {
-    await initStripePaymentIntent();
-  }
+const viewerSummary = computed<CheckoutViewerSummary | null>(() => viewer.value as CheckoutViewerSummary | null);
+const viewerEmail = computed<string>(() => customer.value?.billing?.email || viewerSummary.value?.email || '');
+const viewerFirstName = computed<string>(() => customer.value?.billing?.firstName || viewerSummary.value?.firstName || '');
+const viewerLastName = computed<string>(() => customer.value?.billing?.lastName || viewerSummary.value?.lastName || '');
+const viewerGreeting = computed<string>(() => {
+  const name = [viewerFirstName.value, viewerLastName.value].filter(Boolean).join(' ');
+  return name ? `Welcome back, ${name}` : 'Welcome';
 });
-
-watch(
-  stripeGateway,
-  (gateway) => {
-    if (gateway && selectedSavedToken.value) {
-      orderInput.value.paymentMethod = gateway;
-    }
-  },
-  { immediate: true },
-);
-
-const isInvalidEmail = ref<boolean>(false);
-const stripe: Stripe | null = stripeKey ? await loadStripe(stripeKey) : null;
-const elements = ref();
-const isPaid = ref<boolean>(false);
-const stripeClientSecret = ref<string | null>(null);
-const stripeCustomerSessionSecret = ref<string | null>(null);
-const stripeCurrency = computed(() => (runtimeConfig.public?.CURRENCY_CODE || 'USD').toLowerCase());
-const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
-
-const resolveStripeAmount = (rawTotal: string | number | null | undefined, currency: string): number => {
-  const parsed = Number.parseFloat(String(rawTotal ?? '0'));
-  if (!Number.isFinite(parsed)) return 0;
-
-  const fractionDigits =
-    new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: currency.toUpperCase(),
-    }).resolvedOptions().maximumFractionDigits ?? 2;
-
-  return Math.round(parsed * 10 ** fractionDigits);
-};
-
-const stripeAmount = computed(() => resolveStripeAmount(cart.value?.rawTotal ?? '0', stripeCurrency.value));
-const viewerEmail = computed<string>(() => customer.value?.billing?.email || viewerAsCheckoutViewer.value?.email || '');
-const viewerFirstName = computed<string>(() => customer.value?.billing?.firstName || viewerAsCheckoutViewer.value?.firstName || '');
-const viewerGreeting = computed<string>(() =>
-  viewerFirstName.value ? `Welcome back, ${customer.value?.billing?.firstName} ${customer.value?.billing?.lastName || ''}` : 'Welcome',
-);
-const selectedPaymentMethodId = computed<string>(() => resolvePaymentMethodId(orderInput.value.paymentMethod));
 const isCheckoutDisabled = computed<boolean>(() => {
   if (isProcessingOrder.value || !selectedPaymentMethodId.value) return true;
-  if (selectedPaymentMethodId.value === 'stripe') {
-    if (!stripe) return true;
-    if (selectedSavedToken.value) return false; // PI created fresh at submit time
-    return !elements.value;
-  }
-  return false;
+  return !isActiveGatewayReady.value;
 });
 
 // Sync the shipping-address toggle with orderInput so checkout logic stays consistent
@@ -194,43 +78,6 @@ const hasAvailableShippingMethods = computed<boolean>(() => {
   return !!cart.value?.availableShippingMethods?.[0]?.rates?.length;
 });
 
-watch(
-  () => canSavePaymentMethod.value,
-  (canSave) => {
-    if (!canSave) savePaymentMethod.value = false;
-  },
-  { immediate: true },
-);
-
-// Eagerly create a PaymentIntent so StripeElement can mount in intent mode.
-const initStripePaymentIntent = async () => {
-  if (!stripe || selectedSavedToken.value) return;
-
-  const customerId = stripeCustomerId.value;
-
-  try {
-    const vars: any = { stripePaymentMethod: 'PAYMENT' as any, saveForFuture: false };
-    if (customerId) vars.customerId = customerId;
-
-    const { stripePaymentIntent } = await GqlGetStripePaymentIntent(vars);
-
-    if (stripePaymentIntent?.error) {
-      console.warn('[Stripe] PaymentIntent init error:', stripePaymentIntent.error);
-      return;
-    }
-    if (stripePaymentIntent?.clientSecret) {
-      stripeClientSecret.value = stripePaymentIntent.clientSecret;
-      /** Don't attach the CustomerSession: it requires setup_future_usage on the PI,
-       * which this eager init doesn't set. Saved cards are shown via our own UI. */
-      stripeCustomerSessionSecret.value = null;
-    } else {
-      console.warn('[Stripe] No clientSecret in response');
-    }
-  } catch (err) {
-    console.error('[Stripe] Failed to init PaymentIntent:', err);
-  }
-};
-
 watch(shipToDifferentAddress, (newValue) => {
   if (!customer.value?.billing) return;
 
@@ -244,29 +91,11 @@ watch(shipToDifferentAddress, (newValue) => {
   }
 });
 
-/** stripeCustomerId loads async (after refreshCart). Re-init when it arrives so
- * the PaymentIntent has the customer attached. */
-watch(stripeCustomerId, (newId, oldId) => {
-  if (!stripe) return;
-  if (selectedSavedToken.value) return;
-  if (newId && newId !== oldId) {
-    stripeClientSecret.value = null;
-    stripeCustomerSessionSecret.value = null;
-    initStripePaymentIntent();
-  }
-});
-
-onBeforeMount(async () => {
+onBeforeMount(() => {
   if (query.cancel_order) window.close();
 
   if (customer.value && !customer.value.shipping && customer.value.billing) {
     customer.value.shipping = { ...customer.value.billing };
-  }
-
-  // Wait one tick so refreshCart() has a chance to populate stripeCustomerId first.
-  if (stripe && !selectedSavedToken.value) {
-    await nextTick();
-    await initStripePaymentIntent();
   }
 });
 
@@ -283,161 +112,48 @@ watchEffect(() => {
   }
 });
 
+watch(
+  selectedPaymentMethodId,
+  (gatewayId) => {
+    if (gatewayId) void setActiveGateway(gatewayId);
+  },
+  { immediate: true },
+);
+
+const handleGatewaySelect = (gateway: PaymentGateway): void => {
+  orderInput.value.paymentMethod = gateway;
+  void setActiveGateway(gateway);
+};
+
 const payNow = async () => {
   buttonText.value = t('general.processing');
   checkoutError.value = null;
-  resetStripeOrderMeta();
+  await setActiveGateway(orderInput.value.paymentMethod);
+  resetActiveGateway();
   orderInput.value.transactionId = '';
-  isPaid.value = false;
 
   if (isCheckoutDisabled.value) {
-    if (!selectedPaymentMethodId.value) {
-      checkoutError.value = 'Please select a payment method before checking out.';
-    } else if (selectedPaymentMethodId.value === 'stripe') {
-      checkoutError.value = 'Your payment details are still loading. Please wait a moment and try again.';
-    }
-
+    checkoutError.value = getActiveGatewayDisabledMessage() || 'Please select a payment method before checking out.';
     buttonText.value = t('shop.checkoutButton');
     return;
   }
 
+  let paymentResult;
   try {
-    if (selectedPaymentMethodId.value === 'stripe' && stripe) {
-      // ── Saved card ──────────────────────────────────────────────────────────
-      if (selectedSavedToken.value) {
-        // Use the customer ID from the token itself — stale user meta can differ.
-        const tokenCustomerId = selectedSavedToken.value.customerId || undefined;
-
-        if (!tokenCustomerId) {
-          throw new Error('Saved payment method is missing its Stripe customer ID.');
-        }
-
-        // Always create a fresh PI — the eager one may lack the customer association.
-        const { stripePaymentIntent } = await GqlGetStripePaymentIntent({
-          stripePaymentMethod: 'PAYMENT' as any,
-          customerId: tokenCustomerId,
-          saveForFuture: false,
-        } as any);
-        if (stripePaymentIntent?.error) throw new Error(stripePaymentIntent.error);
-        const clientSecret = stripePaymentIntent?.clientSecret ?? null;
-        if (!clientSecret) throw new Error('Payment intent not available. Please refresh and try again.');
-
-        const { error, paymentIntent } = await stripe.confirmPayment({
-          clientSecret,
-          confirmParams: {
-            payment_method: selectedSavedToken.value.token,
-            return_url: `${window.location.origin}/checkout/order-received`,
-          },
-          redirect: 'if_required',
-        });
-
-        if (error) throw new Error(error.message);
-
-        if (paymentIntent) {
-          upsertOrderMeta('_stripe_payment_intent_id', paymentIntent.id);
-          if (paymentIntent.payment_method) {
-            upsertOrderMeta('_stripe_payment_method_id', String(paymentIntent.payment_method));
-          }
-          upsertOrderMeta('_stripe_source_id', paymentIntent.id);
-          upsertOrderMeta('_stripe_charge_captured', 'yes');
-          upsertOrderMeta('_wc_stripe_payment_method_type', 'card');
-          isPaid.value = paymentIntent.status === 'succeeded' || paymentIntent.status === 'processing';
-          orderInput.value.transactionId = paymentIntent.id;
-        }
-      } else if (elements.value) {
-        // ── New card ────────────────────────────────────────────────────────────
-        const saveForFuture = canSavePaymentMethod.value && savePaymentMethod.value;
-
-        const { error: submitError } = await elements.value.submit();
-        if (submitError) {
-          console.error('Form validation failed:', submitError);
-          throw new Error(submitError.message);
-        }
-
-        let clientSecret = stripeClientSecret.value;
-        if (!clientSecret) {
-          const { stripePaymentIntent } = await GqlGetStripePaymentIntent({
-            stripePaymentMethod: 'PAYMENT' as any,
-            customerId: stripeCustomerId.value || undefined,
-            saveForFuture,
-          } as any);
-
-          if (stripePaymentIntent?.error) {
-            checkoutError.value = stripePaymentIntent.error;
-            throw new Error(stripePaymentIntent.error);
-          }
-
-          clientSecret = stripePaymentIntent?.clientSecret ?? null;
-        }
-
-        if (!clientSecret) throw new Error('Payment intent not available. Please refresh and try again.');
-
-        checkoutError.value = null;
-
-        const { error, paymentIntent } = await stripe.confirmPayment({
-          elements: elements.value,
-          clientSecret,
-          confirmParams: {
-            return_url: `${window.location.origin}/checkout/order-received`,
-            payment_method_data: {
-              billing_details: {
-                name: `${customer.value?.billing?.firstName || ''} ${customer.value?.billing?.lastName || ''}`.trim() || undefined,
-                email: customer.value?.billing?.email || undefined,
-                phone: customer.value?.billing?.phone || undefined,
-                address: {
-                  line1: customer.value?.billing?.address1 || undefined,
-                  line2: customer.value?.billing?.address2 || undefined,
-                  city: customer.value?.billing?.city || undefined,
-                  state: customer.value?.billing?.state || undefined,
-                  postal_code: customer.value?.billing?.postcode || undefined,
-                  country: customer.value?.billing?.country || undefined,
-                },
-              },
-            },
-          },
-          redirect: 'if_required',
-        });
-
-        if (error) {
-          console.error('Payment failed:', error);
-          throw new Error(error.message);
-        }
-
-        if (paymentIntent) {
-          upsertOrderMeta('_stripe_payment_intent_id', paymentIntent.id);
-          if (paymentIntent.payment_method) {
-            upsertOrderMeta('_stripe_payment_method_id', String(paymentIntent.payment_method));
-          }
-          upsertOrderMeta('_stripe_source_id', paymentIntent.id);
-          upsertOrderMeta('_stripe_fee', '0');
-          upsertOrderMeta('_stripe_net', paymentIntent.amount.toString());
-          upsertOrderMeta('_stripe_currency', paymentIntent.currency);
-          upsertOrderMeta('_stripe_charge_captured', 'yes');
-          upsertOrderMeta('_wc_stripe_payment_method_type', 'card');
-          isPaid.value = paymentIntent.status === 'succeeded' || paymentIntent.status === 'processing';
-          orderInput.value.transactionId = paymentIntent.id;
-        }
-      }
+    paymentResult = await processActiveGatewayPayment();
+    if (!paymentResult.success) {
+      checkoutError.value = paymentResult.error || 'Payment processing failed. Please try again.';
+      buttonText.value = t('shop.checkoutButton');
+      return;
     }
   } catch (error) {
     console.error('Checkout error:', error);
-
-    const errorMessage = error instanceof Error ? error.message : 'An unexpected error occurred during checkout';
-    checkoutError.value = errorMessage;
+    checkoutError.value = error instanceof Error ? error.message : 'An unexpected error occurred during checkout';
     buttonText.value = t('shop.checkoutButton');
     return;
   }
 
-  await processCheckout(isPaid.value);
-};
-
-const handleStripeElement = (stripeElements: StripeElements | null): void => {
-  elements.value = stripeElements;
-};
-
-const handleGatewaySelect = (gateway: any): void => {
-  orderInput.value.paymentMethod = gateway;
-  selectedSavedToken.value = null;
+  await processCheckout(paymentResult.isPaid);
 };
 
 const checkEmailOnBlur = (email?: string | null): void => {
@@ -478,9 +194,9 @@ useSeoMeta({
                 <span class="text-gray-400">Email: </span>
                 <span class="truncate" :title="viewerEmail">{{ viewerEmail }}</span>
               </p>
-              <p v-if="viewer.databaseId" class="flex flex-wrap items-center gap-2 text-sm text-gray-600">
+              <p v-if="viewerSummary?.databaseId" class="flex flex-wrap items-center gap-2 text-sm text-gray-600">
                 <span class="text-gray-400">Customer ID: </span>
-                <span>#{{ viewer.databaseId }}</span>
+                <span>#{{ viewerSummary.databaseId }}</span>
               </p>
             </div>
           </div>
@@ -579,35 +295,12 @@ useSeoMeta({
             </h3>
 
             <PaymentOptions
-              v-model:selected-saved-payment-method="selectedSavedToken"
               :model-value="orderInput.paymentMethod"
               class="mb-4"
               :payment-gateways="checkoutPaymentGateways"
-              :saved-payment-methods="savedPaymentMethods"
               @update:model-value="handleGatewaySelect" />
 
-            <!-- Stripe Payment Element (always mounted, shown only when active) -->
-            <StripeElement
-              v-if="stripe"
-              v-show="selectedPaymentMethodId === 'stripe' && !selectedSavedToken"
-              :stripe
-              :client-secret="stripeClientSecret"
-              :customer-session-client-secret="stripeCustomerSessionSecret"
-              :customer-id="stripeCustomerId"
-              :amount="stripeAmount"
-              :currency="stripeCurrency"
-              :save-for-future="canSavePaymentMethod && savePaymentMethod"
-              @update-element="handleStripeElement" />
-
-            <div v-if="selectedPaymentMethodId === 'stripe' && canSavePaymentMethod && !selectedSavedToken" class="mt-3 flex items-start gap-2">
-              <input
-                id="save-payment-method"
-                v-model="savePaymentMethod"
-                type="checkbox"
-                name="save-payment-method"
-                class="mt-0.5 h-4 w-4 rounded-sm border-gray-300 bg-white text-primary focus:ring-3 focus:ring-primary" />
-              <label for="save-payment-method" class="text-sm font-medium text-gray-700"> Save payment information to my account for future purchases. </label>
-            </div>
+            <PaymentGatewayComponent :gateway="orderInput.paymentMethod" />
           </div>
 
           <!-- Order note -->

--- a/woonuxt_base/app/plugins/payment-gateways/README.md
+++ b/woonuxt_base/app/plugins/payment-gateways/README.md
@@ -1,0 +1,28 @@
+# Payment Gateway Plugins
+
+Each payment gateway implements the `PaymentGatewayPlugin` interface and registers itself with `usePaymentGateways()` from its own Nuxt plugin file.
+
+The checkout page should only coordinate the selected gateway. Gateway-specific UI, validation, readiness, reset, and client-side payment processing belong in these plugins.
+
+Current built-in plugins:
+
+- `stripe.ts`: Stripe Payment Element, saved card support, and Stripe order metadata.
+- `paypal.ts`: PayPal and PPCP redirect gateways. Current redirect handling stays in `useCheckout()`.
+- `cod.ts`: Cash on delivery.
+- `cheque.ts`: Cheque payments.
+
+New gateways should export a `PaymentGatewayPlugin` object or a factory that returns one. The plugin can also provide `icon` or `iconName` so generic checkout UI does not need gateway-specific conditions.
+
+To enable a gateway, add its plugin file to `woonuxt_base/nuxt.config.ts`:
+
+```ts
+plugins: [
+  resolve('./app/plugins/init.ts'),
+  resolve('./app/plugins/payment-gateways/stripe.ts'),
+  resolve('./app/plugins/payment-gateways/paypal.ts'),
+  resolve('./app/plugins/payment-gateways/cod.ts'),
+  resolve('./app/plugins/payment-gateways/cheque.ts'),
+];
+```
+
+To add a new gateway, create `your-gateway.ts`, register it inside `defineNuxtPlugin()`, then add that file to the plugin list.

--- a/woonuxt_base/app/plugins/payment-gateways/cheque.ts
+++ b/woonuxt_base/app/plugins/payment-gateways/cheque.ts
@@ -1,0 +1,12 @@
+import type { PaymentGatewayPlugin } from '#types/payment-gateway-plugin';
+
+export const chequeGatewayPlugin: PaymentGatewayPlugin = {
+  id: 'cheque',
+  name: 'Cheque payments',
+  iconName: 'ion:document-text-outline',
+};
+
+export default defineNuxtPlugin(() => {
+  const { registerGateway } = usePaymentGateways();
+  registerGateway(chequeGatewayPlugin);
+});

--- a/woonuxt_base/app/plugins/payment-gateways/cod.ts
+++ b/woonuxt_base/app/plugins/payment-gateways/cod.ts
@@ -1,0 +1,12 @@
+import type { PaymentGatewayPlugin } from '#types/payment-gateway-plugin';
+
+export const codGatewayPlugin: PaymentGatewayPlugin = {
+  id: 'cod',
+  name: 'Cash on delivery',
+  iconName: 'ion:cash-outline',
+};
+
+export default defineNuxtPlugin(() => {
+  const { registerGateway } = usePaymentGateways();
+  registerGateway(codGatewayPlugin);
+});

--- a/woonuxt_base/app/plugins/payment-gateways/paypal.ts
+++ b/woonuxt_base/app/plugins/payment-gateways/paypal.ts
@@ -1,0 +1,19 @@
+import type { PaymentGatewayPlugin } from '#types/payment-gateway-plugin';
+
+export const paypalGatewayPlugin: PaymentGatewayPlugin = {
+  id: 'paypal',
+  name: 'PayPal',
+  icon: '/icons/payment/paypal.svg',
+};
+
+export const ppcpGatewayPlugin: PaymentGatewayPlugin = {
+  id: 'ppcp-gateway',
+  name: 'PayPal Payments',
+  icon: '/icons/payment/paypal.svg',
+};
+
+export default defineNuxtPlugin(() => {
+  const { registerGateway } = usePaymentGateways();
+  registerGateway(paypalGatewayPlugin);
+  registerGateway(ppcpGatewayPlugin);
+});

--- a/woonuxt_base/app/plugins/payment-gateways/stripe.ts
+++ b/woonuxt_base/app/plugins/payment-gateways/stripe.ts
@@ -1,0 +1,443 @@
+import type { PaymentGateway, Viewer } from '#types/gql';
+import type { PaymentGatewayOption, PaymentGatewayPlugin } from '#types/payment-gateway-plugin';
+import type { Stripe, StripeElements } from '@stripe/stripe-js';
+
+import type { GetStripePaymentIntentQueryVariables } from '#gql/default';
+import StripePaymentGateway from '../../components/payments/StripePaymentGateway.vue';
+import { StripePaymentMethodEnum } from '#gql/default';
+import { loadStripe } from '@stripe/stripe-js';
+
+type SavedPaymentMethod = {
+  id: number;
+  token: string;
+  customerId?: string | null;
+  last4: string;
+  expiryMonth: string;
+  expiryYear: string;
+  cardType: string;
+  isDefault: boolean;
+};
+
+type CheckoutViewer = Viewer & {
+  stripeCustomerId?: string | null;
+  savedPaymentMethods?: SavedPaymentMethod[] | null;
+};
+
+const STRIPE_META_KEYS = new Set([
+  '_stripe_payment_intent_id',
+  '_stripe_payment_method_id',
+  '_stripe_source_id',
+  '_stripe_fee',
+  '_stripe_net',
+  '_stripe_currency',
+  '_stripe_charge_captured',
+  '_wc_stripe_payment_method_type',
+  '_stripe_intent_id',
+]);
+
+const resolveStripeAmount = (rawTotal: string | number | null | undefined, currency: string): number => {
+  const parsed = Number.parseFloat(String(rawTotal ?? '0'));
+  if (!Number.isFinite(parsed)) return 0;
+
+  const fractionDigits =
+    new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currency.toUpperCase(),
+    }).resolvedOptions().maximumFractionDigits ?? 2;
+
+  return Math.round(parsed * 10 ** fractionDigits);
+};
+
+const normalizedCardBrand = (cardType?: string | null): string => {
+  const brand = cardType?.toLowerCase().replace(/[\s_-]/g, '') || '';
+  if (brand.includes('visa')) return 'visa';
+  if (brand.includes('master')) return 'mastercard';
+  return 'card';
+};
+
+const cardBrandIcon = (cardType?: string | null): string | null => {
+  const brand = normalizedCardBrand(cardType);
+  return brand === 'card' ? null : `/icons/payment/${brand}.svg`;
+};
+
+export default defineNuxtPlugin(() => {
+  const { registerGateway } = usePaymentGateways();
+  const { cart, paymentGateways } = useCart();
+  const { customer, viewer } = useAuth();
+  const { orderInput, checkoutError, resolvePaymentMethodId } = useCheckout();
+  const runtimeConfig = useRuntimeConfig();
+  const route = useRoute();
+  const stripeKey = runtimeConfig.public?.STRIPE_PUBLISHABLE_KEY || null;
+
+  const stripe = useState<Stripe | null>('stripeClient', () => null);
+  const elements = useState<StripeElements | null>('stripeElements', () => null);
+  const savePaymentMethod = useState<boolean>('stripeSavePaymentMethod', () => false);
+  const selectedSavedToken = useState<SavedPaymentMethod | null>('stripeSelectedSavedToken', () => null);
+  const stripeClientSecret = useState<string | null>('stripeClientSecret', () => null);
+  const stripeClientSecretSaveForFuture = useState<boolean | null>('stripeClientSecretSaveForFuture', () => null);
+  let stripeLoader: Promise<Stripe | null> | null = null;
+
+  const viewerAsCheckoutViewer = computed<CheckoutViewer | null>(() => viewer.value as CheckoutViewer | null);
+  const stripeCustomerId = computed<string | null>(() => viewerAsCheckoutViewer.value?.stripeCustomerId ?? null);
+  const savedPaymentMethods = computed<SavedPaymentMethod[]>(() => viewerAsCheckoutViewer.value?.savedPaymentMethods ?? []);
+  const isCreatingAccountAtCheckout = computed<boolean>(() => !viewer.value && !!orderInput.value.createAccount);
+  const canSavePaymentMethod = computed<boolean>(() => !!viewer.value || isCreatingAccountAtCheckout.value);
+  const stripeGateway = computed(() => paymentGateways.value?.nodes.find((gateway) => gateway.id === 'stripe') ?? null);
+  const stripeCurrency = computed(() => (runtimeConfig.public?.CURRENCY_CODE || 'USD').toLowerCase());
+  const stripeAmount = computed(() => resolveStripeAmount(cart.value?.rawTotal ?? '0', stripeCurrency.value));
+  const selectedPaymentMethodId = computed<string>(() => resolvePaymentMethodId(orderInput.value.paymentMethod));
+  const isCheckoutRoute = computed<boolean>(() => route.path === '/checkout' || route.path === '/checkout/');
+  const isStripeSelected = computed<boolean>(() => selectedPaymentMethodId.value === 'stripe');
+  const isStripeCheckoutDisabled = computed<boolean>(() => {
+    if (!isStripeSelected.value) return false;
+    if (!stripe.value) return true;
+    if (selectedSavedToken.value) return false;
+    return !elements.value;
+  });
+
+  const clearStripeElements = (): void => {
+    elements.value = null;
+  };
+
+  const clearStripePaymentIntent = (): void => {
+    clearStripeElements();
+    stripeClientSecret.value = null;
+    stripeClientSecretSaveForFuture.value = null;
+  };
+
+  const ensureStripeLoaded = async (): Promise<Stripe | null> => {
+    if (!import.meta.client || !stripeKey) return null;
+    if (stripe.value) return stripe.value;
+
+    stripeLoader ??= loadStripe(stripeKey);
+    stripe.value = await stripeLoader;
+    return stripe.value;
+  };
+
+  const activateStripeGateway = (): void => {
+    if (stripeGateway.value) {
+      orderInput.value.paymentMethod = stripeGateway.value;
+    }
+  };
+
+  const upsertOrderMeta = (key: string, value: string): void => {
+    const existingMeta = orderInput.value.metaData.find((entry: { key: string }) => entry.key === key);
+    if (existingMeta) {
+      existingMeta.value = value;
+      return;
+    }
+
+    orderInput.value.metaData.push({ key, value });
+  };
+
+  const resetStripeOrderMeta = (): void => {
+    orderInput.value.metaData = orderInput.value.metaData.filter((entry: { key: string }) => !STRIPE_META_KEYS.has(entry.key));
+  };
+
+  const createPaymentIntentVariables = (
+    overrides: Omit<GetStripePaymentIntentQueryVariables, 'stripePaymentMethod'> = {},
+  ): GetStripePaymentIntentQueryVariables => ({
+    stripePaymentMethod: StripePaymentMethodEnum.PAYMENT,
+    ...overrides,
+  });
+
+  const initStripePaymentIntent = async (saveForFuture = false) => {
+    if (!isCheckoutRoute.value || !isStripeSelected.value || selectedSavedToken.value) return;
+    if (!(await ensureStripeLoaded())) return;
+
+    const customerId = stripeCustomerId.value;
+
+    try {
+      const vars = createPaymentIntentVariables({ saveForFuture });
+      if (customerId) vars.customerId = customerId;
+
+      const { stripePaymentIntent } = await GqlGetStripePaymentIntent(vars);
+
+      if (stripePaymentIntent?.error) {
+        console.warn('[Stripe] PaymentIntent init error:', stripePaymentIntent.error);
+        return;
+      }
+      if (stripePaymentIntent?.clientSecret) {
+        stripeClientSecret.value = stripePaymentIntent.clientSecret;
+        stripeClientSecretSaveForFuture.value = saveForFuture;
+      } else {
+        console.warn('[Stripe] No clientSecret in response');
+      }
+    } catch (err) {
+      console.error('[Stripe] Failed to init PaymentIntent:', err);
+    }
+  };
+
+  const applyStripePaymentIntent = (paymentIntent: { id: string; payment_method?: unknown; amount: number; currency: string; status: string }): boolean => {
+    upsertOrderMeta('_stripe_payment_intent_id', paymentIntent.id);
+    if (paymentIntent.payment_method) {
+      upsertOrderMeta('_stripe_payment_method_id', String(paymentIntent.payment_method));
+    }
+    upsertOrderMeta('_stripe_source_id', paymentIntent.id);
+    upsertOrderMeta('_stripe_charge_captured', 'yes');
+    upsertOrderMeta('_wc_stripe_payment_method_type', 'card');
+    orderInput.value.transactionId = paymentIntent.id;
+    return paymentIntent.status === 'succeeded' || paymentIntent.status === 'processing';
+  };
+
+  const confirmSavedPaymentMethod = async (): Promise<boolean> => {
+    const stripeClient = await ensureStripeLoaded();
+    if (!stripeClient || !selectedSavedToken.value) return false;
+
+    const tokenCustomerId = selectedSavedToken.value.customerId || undefined;
+    if (!tokenCustomerId) {
+      throw new Error('Saved payment method is missing its Stripe customer ID.');
+    }
+
+    const { stripePaymentIntent } = await GqlGetStripePaymentIntent(createPaymentIntentVariables({ customerId: tokenCustomerId, saveForFuture: false }));
+    if (stripePaymentIntent?.error) throw new Error(stripePaymentIntent.error);
+    const clientSecret = stripePaymentIntent?.clientSecret ?? null;
+    if (!clientSecret) throw new Error('Payment intent not available. Please refresh and try again.');
+
+    const { error, paymentIntent } = await stripeClient.confirmPayment({
+      clientSecret,
+      confirmParams: {
+        payment_method: selectedSavedToken.value.token,
+        return_url: `${window.location.origin}/checkout/order-received`,
+      },
+      redirect: 'if_required',
+    });
+
+    if (error) throw new Error(error.message);
+    return paymentIntent ? applyStripePaymentIntent(paymentIntent) : false;
+  };
+
+  const confirmNewPaymentMethod = async (): Promise<boolean> => {
+    const stripeClient = await ensureStripeLoaded();
+    if (!stripeClient) throw new Error('Stripe is not available. Please refresh and try again.');
+    if (!elements.value) throw new Error('Your payment details are still loading. Please wait a moment and try again.');
+
+    const saveForFuture = canSavePaymentMethod.value && savePaymentMethod.value;
+    if (stripeClientSecret.value && stripeClientSecretSaveForFuture.value !== saveForFuture) {
+      clearStripePaymentIntent();
+      await initStripePaymentIntent(saveForFuture);
+      throw new Error('Your payment details are still loading. Please wait a moment and try again.');
+    }
+
+    const { error: submitError } = await elements.value.submit();
+    if (submitError) {
+      console.error('Form validation failed:', submitError);
+      throw new Error(submitError.message);
+    }
+
+    let clientSecret = stripeClientSecret.value;
+    if (!clientSecret) {
+      const { stripePaymentIntent } = await GqlGetStripePaymentIntent(
+        createPaymentIntentVariables({
+          customerId: stripeCustomerId.value || undefined,
+          saveForFuture,
+        }),
+      );
+
+      if (stripePaymentIntent?.error) {
+        checkoutError.value = stripePaymentIntent.error;
+        throw new Error(stripePaymentIntent.error);
+      }
+
+      clientSecret = stripePaymentIntent?.clientSecret ?? null;
+    }
+
+    if (!clientSecret) throw new Error('Payment intent not available. Please refresh and try again.');
+
+    checkoutError.value = null;
+
+    const { error, paymentIntent } = await stripeClient.confirmPayment({
+      elements: elements.value,
+      clientSecret,
+      confirmParams: {
+        return_url: `${window.location.origin}/checkout/order-received`,
+        payment_method_data: {
+          billing_details: {
+            name: `${customer.value?.billing?.firstName || ''} ${customer.value?.billing?.lastName || ''}`.trim() || undefined,
+            email: customer.value?.billing?.email || undefined,
+            phone: customer.value?.billing?.phone || undefined,
+            address: {
+              line1: customer.value?.billing?.address1 || undefined,
+              line2: customer.value?.billing?.address2 || undefined,
+              city: customer.value?.billing?.city || undefined,
+              state: customer.value?.billing?.state || undefined,
+              postal_code: customer.value?.billing?.postcode || undefined,
+              country: customer.value?.billing?.country || undefined,
+            },
+          },
+        },
+      },
+      redirect: 'if_required',
+    });
+
+    if (error) {
+      console.error('Payment failed:', error);
+      throw new Error(error.message);
+    }
+
+    if (paymentIntent) {
+      const paymentIsPaid = applyStripePaymentIntent(paymentIntent);
+      upsertOrderMeta('_stripe_fee', '0');
+      upsertOrderMeta('_stripe_net', paymentIntent.amount.toString());
+      upsertOrderMeta('_stripe_currency', paymentIntent.currency);
+      return paymentIsPaid;
+    }
+
+    return false;
+  };
+
+  const confirmStripePayment = async (): Promise<boolean> => {
+    if (selectedPaymentMethodId.value !== 'stripe') return false;
+
+    if (selectedSavedToken.value) {
+      return await confirmSavedPaymentMethod();
+    } else {
+      return await confirmNewPaymentMethod();
+    }
+  };
+
+  const getCheckoutDisabledMessage = (): string => {
+    if (!selectedPaymentMethodId.value) return 'Please select a payment method before checking out.';
+    if (selectedPaymentMethodId.value === 'stripe') return 'Your payment details are still loading. Please wait a moment and try again.';
+    return '';
+  };
+
+  const selectSavedPaymentMethod = (method: SavedPaymentMethod): void => {
+    clearStripeElements();
+    selectedSavedToken.value = method;
+    activateStripeGateway();
+  };
+
+  const selectNewPaymentMethod = (): void => {
+    clearStripeElements();
+    selectedSavedToken.value = null;
+  };
+
+  const getStripePaymentOptions = (gateway: PaymentGateway): PaymentGatewayOption[] => [
+    ...savedPaymentMethods.value.map((method, index) => ({
+      id: `stripe-saved-${method.id}`,
+      gateway,
+      title: method.cardType,
+      details: [`•••• ${method.last4}`, `expires ${method.expiryMonth}/${method.expiryYear}`],
+      icon: cardBrandIcon(method.cardType),
+      iconName: 'ion:card-outline',
+      badge: method.isDefault ? 'Default' : null,
+      sortOrder: index,
+      isSelected: selectedSavedToken.value?.id === method.id,
+      onSelect: () => selectSavedPaymentMethod(method),
+    })),
+    {
+      id: 'stripe-new-payment-method',
+      gateway,
+      title: 'Credit / Debit Card',
+      iconName: 'ion:card-outline',
+      sortOrder: savedPaymentMethods.value.length + 100,
+      isSelected: isStripeSelected.value && !selectedSavedToken.value,
+      onSelect: selectNewPaymentMethod,
+    },
+  ];
+
+  watch(
+    [savedPaymentMethods, isCheckoutRoute],
+    ([methods, onCheckout]) => {
+      if (!onCheckout) return;
+      if (methods.length > 0 && !selectedSavedToken.value) {
+        selectedSavedToken.value = methods.find((method) => method.isDefault) ?? methods[0]!;
+        activateStripeGateway();
+      }
+    },
+    { immediate: true },
+  );
+
+  watch(selectedSavedToken, async (token, previousToken) => {
+    if (token) {
+      clearStripeElements();
+      activateStripeGateway();
+      return;
+    }
+
+    if (previousToken && !stripeClientSecret.value) {
+      await initStripePaymentIntent(canSavePaymentMethod.value && savePaymentMethod.value);
+    }
+  });
+
+  watch(
+    [stripeGateway, isCheckoutRoute],
+    ([gateway, onCheckout]) => {
+      if (onCheckout && gateway && selectedSavedToken.value) {
+        orderInput.value.paymentMethod = gateway;
+      }
+    },
+    { immediate: true },
+  );
+
+  watch(
+    () => canSavePaymentMethod.value,
+    (canSave) => {
+      if (!canSave) savePaymentMethod.value = false;
+    },
+    { immediate: true },
+  );
+
+  watch(savePaymentMethod, async (saveForFuture) => {
+    if (!isCheckoutRoute.value || !isStripeSelected.value || selectedSavedToken.value) return;
+    if (!stripeClientSecret.value || stripeClientSecretSaveForFuture.value === saveForFuture) return;
+
+    clearStripePaymentIntent();
+    await initStripePaymentIntent(saveForFuture);
+  });
+
+  watch(stripeCustomerId, (newId, oldId) => {
+    if (!isCheckoutRoute.value || !isStripeSelected.value) return;
+    if (selectedSavedToken.value) return;
+    if (newId && newId !== oldId) {
+      clearStripePaymentIntent();
+      initStripePaymentIntent(canSavePaymentMethod.value && savePaymentMethod.value);
+    }
+  });
+
+  const stripeGatewayPlugin: PaymentGatewayPlugin = {
+    id: 'stripe',
+    name: 'Stripe',
+    iconName: 'ion:card-outline',
+    component: StripePaymentGateway,
+    getPaymentOptions: getStripePaymentOptions,
+    onSelect: async () => {
+      await ensureStripeLoaded();
+      if (!selectedSavedToken.value && !stripeClientSecret.value) {
+        await initStripePaymentIntent(canSavePaymentMethod.value && savePaymentMethod.value);
+      }
+    },
+    onDeselect: () => {
+      selectedSavedToken.value = null;
+      clearStripeElements();
+    },
+    isReady: () => !isStripeCheckoutDisabled.value,
+    getDisabledMessage: getCheckoutDisabledMessage,
+    reset: resetStripeOrderMeta,
+    processPayment: async () => {
+      const paymentIsPaid = await confirmStripePayment();
+      return { success: true, isPaid: paymentIsPaid };
+    },
+    getComponentProps: () => ({
+      stripe: stripe.value,
+      clientSecret: stripeClientSecret.value,
+      customerId: stripeCustomerId.value,
+      amount: stripeAmount.value,
+      currency: stripeCurrency.value,
+      canSavePaymentMethod: canSavePaymentMethod.value,
+      savePaymentMethod: savePaymentMethod.value,
+      shouldShowStripeElement: isStripeSelected.value && !selectedSavedToken.value,
+    }),
+    getComponentEvents: () => ({
+      updateElement: (element: unknown) => {
+        elements.value = element as StripeElements | null;
+      },
+      updateSavePaymentMethod: (value: unknown) => {
+        savePaymentMethod.value = !!value;
+      },
+    }),
+  };
+
+  registerGateway(stripeGatewayPlugin);
+});

--- a/woonuxt_base/app/queries/getStripePaymentIntent.gql
+++ b/woonuxt_base/app/queries/getStripePaymentIntent.gql
@@ -6,6 +6,5 @@ query getStripePaymentIntent($stripePaymentMethod: StripePaymentMethodEnum!, $cu
     id
     currency
     stripePaymentMethod
-    customerSessionClientSecret
   }
 }

--- a/woonuxt_base/app/types/payment-gateway-plugin.ts
+++ b/woonuxt_base/app/types/payment-gateway-plugin.ts
@@ -1,0 +1,41 @@
+import type { Component } from 'vue';
+import type { PaymentGateway } from '#types/gql';
+
+export type PaymentGatewayEventHandlers = Record<string, (...args: unknown[]) => void>;
+
+export type PaymentGatewayProcessResult = {
+  success: boolean;
+  isPaid: boolean;
+  error?: string;
+};
+
+export type PaymentGatewayOption = {
+  id: string;
+  gateway: PaymentGateway;
+  title: string;
+  description?: string | null;
+  icon?: string | null;
+  iconName?: string;
+  details?: string[];
+  badge?: string | null;
+  sortOrder?: number;
+  isSelected?: boolean;
+  onSelect?: () => void | Promise<void>;
+};
+
+export type PaymentGatewayPlugin = {
+  id: string;
+  name?: string;
+  icon?: string | ((gateway: PaymentGateway) => string | null);
+  iconName?: string;
+  component?: Component;
+  getPaymentOptions?: (gateway: PaymentGateway) => PaymentGatewayOption[];
+  isReady?: () => boolean;
+  getDisabledMessage?: () => string;
+  getComponentProps?: () => Record<string, unknown>;
+  getComponentEvents?: () => PaymentGatewayEventHandlers;
+  onSelect?: (gateway?: PaymentGateway | string | null) => void | Promise<void>;
+  onDeselect?: () => void | Promise<void>;
+  reset?: () => void;
+  processPayment?: () => Promise<PaymentGatewayProcessResult>;
+};

--- a/woonuxt_base/nuxt.config.ts
+++ b/woonuxt_base/nuxt.config.ts
@@ -22,7 +22,14 @@ export default defineNuxtConfig({
     pageTransition: { name: 'page', mode: 'default' },
   },
 
-  plugins: [resolve('./app/plugins/gql-auth.ts'), resolve('./app/plugins/init.ts')],
+  plugins: [
+    resolve('./app/plugins/gql-auth.ts'),
+    resolve('./app/plugins/init.ts'),
+    resolve('./app/plugins/payment-gateways/stripe.ts'),
+    resolve('./app/plugins/payment-gateways/paypal.ts'),
+    resolve('./app/plugins/payment-gateways/cod.ts'),
+    resolve('./app/plugins/payment-gateways/cheque.ts'),
+  ],
 
   components: [{ path: resolve('./app/components'), pathPrefix: false }],
 

--- a/woonuxt_base/types/shims-vue.d.ts
+++ b/woonuxt_base/types/shims-vue.d.ts
@@ -1,0 +1,5 @@
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue';
+  const component: DefineComponent<Record<string, unknown>, Record<string, unknown>, unknown>;
+  export default component;
+}


### PR DESCRIPTION
# Pluginize payment gateways

## Summary
This PR refactors checkout payment handling into a gateway plugin system so each provider owns its UI/state/payment logic, while checkout coordinates selection and order submission.

## What Changed
1. Added a payment gateway plugin architecture and shared gateway lifecycle APIs (register, select, readiness, reset, process payment).
2. Moved gateway-specific logic out of checkout into provider plugins:
   1. Stripe plugin (Payment Element, saved cards, intent/metadata handling).
   2. PayPal/PPCP plugin registration.
   3. COD and Cheque plugin registration.
3. Added reusable payment rendering pieces:
   1. Gateway component host for provider-specific UI.
   2. Updated payment options UI to use plugin-provided icons and behavior.
4. Simplified checkout page responsibilities:
   1. Select active gateway.
   2. Validate readiness.
   3. Delegate payment processing.
   4. Continue with checkout submission.
5. Added Vue type shim support for plugin-based .vue imports used in TS plugin files.

## Why
1. Reduces checkout complexity and coupling.
2. Makes adding new gateways straightforward without editing core checkout logic.
3. Improves maintainability and testability by isolating provider behavior.

## Validation
1. Typecheck run for the base layer.
2. Manual checkout-path verification for Stripe/non-Stripe flows after pluginization.
3. Confirmed branch upstream/tracking issues were handled separately and are not part of this code behavior change.