### PR TITLE
Add Deploy to PandaStack button

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ You can find some common errors and how to fix them [here](https://woonuxt.com/f
 - Once the plugin is activated, configure `GQL_HOST` and `NUXT_IMAGE_DOMAINS`. Check out the `.env.example` file for details.
 
 [![button](https://user-images.githubusercontent.com/5116925/218880214-a16287a7-fd8c-4299-9e65-0871136f0771.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/scottyzen/woonuxt) [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fscottyzen%2FWooNuxt3&repository-name=WooNuxt&env=GQL_HOST,NUXT_IMAGE_DOMAINS)
+[![Deploy to PandaStack](https://dashboard.pandastack.io/deploy-button.svg)](https://dashboard.pandastack.io/deploy?repo=scottyzen/woonuxt&type=static&buildCmd=npm+run+build&outputDir=dist)
 
 ## Large Catalog ISR Setup (10K+ Products)
 


### PR DESCRIPTION
<img src="https://pandastack.io/logo.png" alt="PandaStack" height="40"/>

## Add Deploy to PandaStack button

This PR adds a **[Deploy to PandaStack](https://pandastack.io)** button alongside the existing Vercel button.

**[PandaStack](https://pandastack.io)** is a cloud deployment platform — supports static sites, containerized apps, databases, cronjobs, and more. A great alternative hosting option for your users.

### What this adds
```
[![Deploy to PandaStack](https://dashboard.pandastack.io/deploy-button.svg)](https://dashboard.pandastack.io/deploy?repo=scottyzen/woonuxt)
```

Happy to adjust build settings or output directory if needed. Feel free to close if you'd prefer to keep one button. 🙂