### PR TITLE
Harden first-run store loading without requiring WooNuxt settings plugin

### DIFF
--- a/woonuxt_base/app/components/filtering/ColorFilter.vue
+++ b/woonuxt_base/app/components/filtering/ColorFilter.vue
@@ -9,6 +9,21 @@ const selectedTerms = ref(getFilter(attribute.slug) || []);
 const filterTitle = ref(attribute.label || attribute.slug);
 const isOpen = ref(attribute.openByDefault);
 
+const isValidColorValue = (value?: string) => {
+  const color = value?.trim();
+  if (!color) return false;
+
+  if (import.meta.client && window.CSS) {
+    return CSS.supports('color', color);
+  }
+
+  return /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(color);
+};
+
+const swatchStyle = (color?: string) => {
+  return isValidColorValue(color) ? { '--color': color } : {};
+};
+
 watch(isFiltersActive, () => {
   // uncheck all checkboxes when filters are cleared
   if (!isFiltersActive.value) selectedTerms.value = [];
@@ -26,7 +41,7 @@ const checkboxChanged = () => {
     <Icon name="ion:chevron-down-outline" class="transform text-gray-600" :class="isOpen ? 'rotate-180' : ''" />
   </div>
   <div v-show="isOpen" class="mr-6 max-h-60 grid gap-1.5 swatches overflow-auto custom-scrollbar">
-    <div v-for="color in attribute.terms" :key="color.slug" :style="{ '--color': color.slug }" :title="color.name">
+    <div v-for="color in attribute.terms" :key="color.slug" :style="swatchStyle(color.slug)" :title="color.name">
       <input :id="color.slug" v-model="selectedTerms" class="hidden" type="checkbox" :value="color.slug" @change="checkboxChanged" />
       <label :for="color.slug" class="cursor-pointer m-0"></label>
     </div>
@@ -37,12 +52,12 @@ const checkboxChanged = () => {
 @reference "#tailwind";
 
 .swatches {
-  grid-template-columns: repeat(auto-fit, minmax(24px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(24px, 1fr));
 }
 
 .swatches label {
   @apply rounded-md cursor-pointer shadow-xs m-0 mb-1 w-full block relative;
-  background-color: var(--color, #eee);
+  background-color: var(--color, white);
   filter: saturate(0.75);
   aspect-ratio: 1/1;
   transition: all 0.2s ease;

--- a/woonuxt_base/app/components/productElements/ProductImageGallery.vue
+++ b/woonuxt_base/app/components/productElements/ProductImageGallery.vue
@@ -9,7 +9,7 @@ const props = defineProps({
   mainImage: { type: Object as PropType<ImageFragment>, required: true },
   gallery: { type: Object as PropType<Gallery>, required: true },
   node: { type: Object as PropType<Product | Variation>, required: true },
-  activeVariation: { type: Object as PropType<Variation | null>, required: false },
+  activeVariation: { type: Object as PropType<Variation | null>, default: null },
 });
 
 const primaryImage = computed<ImageFragment>(() => ({
@@ -94,7 +94,7 @@ const imgWidth = 640;
 
     <div
       v-if="gallery.nodes.length"
-      class="my-4 flex gap-4 overflow-auto [scrollbar-width:none] md:grid md:grid-cols-[repeat(auto-fill,minmax(72px,1fr))] [&::-webkit-scrollbar]:hidden">
+      class="my-4 flex gap-4 overflow-auto scrollbar-none md:grid md:grid-cols-[repeat(auto-fill,minmax(72px,1fr))] [&::-webkit-scrollbar]:hidden">
       <NuxtImg
         v-for="galleryImg in galleryImages"
         :key="galleryImg.databaseId"

--- a/woonuxt_base/app/gql/default.ts
+++ b/woonuxt_base/app/gql/default.ts
@@ -33667,7 +33667,7 @@ export const ProductAttributeFragmentDoc = gql`
 }
     `;
 export const ProductWithAttributesFragmentDoc = gql`
-    fragment ProductWithAttributes on ProductWithAttributes {
+    fragment ProductWithAttributes on Product {
   attributes {
     nodes {
       ...ProductAttribute

--- a/woonuxt_base/app/pages/product/[slug].vue
+++ b/woonuxt_base/app/pages/product/[slug].vue
@@ -5,12 +5,19 @@ import type { ExternalProduct, ProductDetail, Variation, VariationAttribute } fr
 const route = useRoute();
 const { storeSettings } = useAppConfig();
 const { addToCart, isUpdatingCart, isAddingToCart, isOptimisticCartMode } = useCart();
-const { frontEndUrl } = useHelpers();
+const { frontEndUrl, getErrorMessage } = useHelpers();
 const { t } = useI18n();
 const gql = useWooGraphQL();
 const slug = route.params.slug as string;
 
-const { data } = await useAsyncGql('getProduct', { slug, frontEndUrl });
+const { data, error } = await useAsyncGql('getProduct', { slug, frontEndUrl });
+if (error.value) {
+  throw showError({
+    statusCode: 502,
+    statusMessage: getErrorMessage(error.value) || `Unable to load product "${slug}" from WordPress`,
+  });
+}
+
 if (!data.value?.product) {
   throw showError({ statusCode: 404, statusMessage: t('shop.productNotFound') });
 }

--- a/woonuxt_base/app/queries/getProduct.gql
+++ b/woonuxt_base/app/queries/getProduct.gql
@@ -39,7 +39,7 @@ query getProduct($slug: ID!, $frontEndUrl: String = "") {
     }
   }
 }
-fragment ProductWithAttributes on ProductWithAttributes {
+fragment ProductWithAttributes on Product {
   attributes {
     nodes {
       ...ProductAttribute

--- a/woonuxt_base/modules/woonuxt-bridge.ts
+++ b/woonuxt_base/modules/woonuxt-bridge.ts
@@ -137,7 +137,7 @@ export default defineNuxtModule({
       settings = data?.woonuxtSettings || {};
     } catch {
       logger.warn(
-        'WooNuxt settings plugin not detected. Continuing with defaults. Install it later for store settings, Stripe keys, SEO profiles, colors, and filter defaults: https://github.com/scottyzen/woonuxt-settings',
+        'WooNuxt settings plugin not detected. Continuing with defaults so the store can run. Install the latest WooNuxt WordPress plugin to unlock store settings, Stripe keys, SEO profiles, colors, and filter defaults: https://github.com/scottyzen/woonuxt/releases',
       );
     }
 

--- a/woonuxt_base/modules/woonuxt-bridge.ts
+++ b/woonuxt_base/modules/woonuxt-bridge.ts
@@ -8,6 +8,25 @@ type EnvSpec = {
   hint?: string;
 };
 
+type WooNuxtSettings = {
+  primary_color?: string | null;
+  logo?: string | null;
+  publicIntrospectionEnabled?: boolean | null;
+  frontEndUrl?: string | null;
+  productsPerPage?: number | string | null;
+  maxPrice?: number | string | null;
+  global_attributes?: Record<string, unknown>[] | null;
+  stripeSettings?: {
+    enabled?: boolean | null;
+    testmode?: string | null;
+    test_publishable_key?: string | null;
+    publishable_key?: string | null;
+  } | null;
+  wooNuxtSEO?: Record<string, unknown>[] | null;
+  currencyCode?: string | null;
+  currencySymbol?: string | null;
+};
+
 const REQUIRED_ENV: EnvSpec[] = [
   {
     key: 'GQL_HOST',
@@ -52,6 +71,7 @@ export default defineNuxtModule({
 
     // Environment variables are guaranteed to be valid at this point
     const GQL_HOST = process.env.GQL_HOST!;
+    const requestHeaders = { Origin: process.env.APP_HOST || 'http://localhost:3000' };
 
     const woonuxtSettings = `{
         primary_color
@@ -78,52 +98,76 @@ export default defineNuxtModule({
         currencySymbol
     }`;
 
-    const query = `
-    query getWooNuxtSettings {
-      woonuxtSettings ${woonuxtSettings}
+    const coreSettingsQuery = `
+    query getWordPressSettings {
       generalSettings { title }
       allSettings { generalSettingsUrl }
     }`;
 
+    const woonuxtSettingsQuery = `
+    query getWooNuxtSettings {
+      woonuxtSettings ${woonuxtSettings}
+    }`;
+
+    let siteTitle = 'WooNuxt';
+    let backendUrl = '';
+    let settings: WooNuxtSettings = {};
+
     try {
       const { data } = await $fetch(GQL_HOST, {
         method: 'POST',
-        body: JSON.stringify({ query }),
-        headers: { Origin: process.env.APP_HOST || 'http://localhost:3000' },
+        body: JSON.stringify({ query: coreSettingsQuery }),
+        headers: requestHeaders,
       });
 
-      // Default env variables
-      process.env.PRIMARY_COLOR = data.woonuxtSettings?.primary_color || '#7F54B2';
-
-      const configuredMaxPrice = Number(data.woonuxtSettings?.maxPrice);
-      const resolvedMaxPrice = Number.isFinite(configuredMaxPrice) && configuredMaxPrice > 0 ? Math.ceil(configuredMaxPrice) : 1000;
-
-      // Default runtimeConfig
-      nuxt.options.runtimeConfig.public.PRIMARY_COLOR = data.woonuxtSettings?.primary_color || '#7F54B2';
-      nuxt.options.runtimeConfig.public.LOGO = data.woonuxtSettings?.logo || null;
-      nuxt.options.runtimeConfig.public.PRODUCTS_PER_PAGE = data.woonuxtSettings?.productsPerPage || process.env.PRODUCTS_PER_PAGE || 24;
-      nuxt.options.runtimeConfig.public.GLOBAL_PRODUCT_ATTRIBUTES = data.woonuxtSettings?.global_attributes || [];
-      nuxt.options.runtimeConfig.public.MAX_PRICE = resolvedMaxPrice;
-      nuxt.options.runtimeConfig.public.FRONT_END_URL = data.woonuxtSettings?.frontEndUrl || null;
-      nuxt.options.runtimeConfig.public.BACKEND_URL = data.allSettings?.generalSettingsUrl || null;
-      nuxt.options.runtimeConfig.public.CURRENCY_CODE = data.woonuxtSettings?.currencyCode || null;
-      nuxt.options.runtimeConfig.public.CURRENCY_SYMBOL = data.woonuxtSettings?.currencySymbol || null;
-      nuxt.options.runtimeConfig.public.WOO_NUXT_SEO = data.woonuxtSettings?.wooNuxtSEO || null;
-      // Site title
-      process.env.SITE_TITLE = data.generalSettings?.title || 'WooNuxt';
-
-      // Stripe
-      if (data.woonuxtSettings?.stripeSettings?.enabled) {
-        nuxt.options.runtimeConfig.public.STRIPE_PUBLISHABLE_KEY =
-          data.woonuxtSettings?.stripeSettings?.testmode === 'yes'
-            ? data.woonuxtSettings?.stripeSettings?.test_publishable_key
-            : data.woonuxtSettings?.stripeSettings?.publishable_key;
-      }
+      siteTitle = data?.generalSettings?.title || siteTitle;
+      backendUrl = data?.allSettings?.generalSettingsUrl || backendUrl;
     } catch (error) {
       logger.error(error);
+      logger.warn('Error fetching WordPress settings. WooNuxt will continue with defaults.');
+    }
+
+    try {
+      const { data } = await $fetch(GQL_HOST, {
+        method: 'POST',
+        body: JSON.stringify({ query: woonuxtSettingsQuery }),
+        headers: requestHeaders,
+      });
+
+      settings = data?.woonuxtSettings || {};
+    } catch {
       logger.warn(
-        'Error fetching woonuxt settings. Make sure you have the latest version woonuxt-settings plugin installed on WordPress. https://github.com/scottyzen/woonuxt-settings',
+        'WooNuxt settings plugin not detected. Continuing with defaults. Install it later for store settings, Stripe keys, SEO profiles, colors, and filter defaults: https://github.com/scottyzen/woonuxt-settings',
       );
+    }
+
+    // Default env variables
+    process.env.PRIMARY_COLOR = settings.primary_color || '#7F54B2';
+
+    const configuredMaxPrice = Number(settings.maxPrice);
+    const resolvedMaxPrice = Number.isFinite(configuredMaxPrice) && configuredMaxPrice > 0 ? Math.ceil(configuredMaxPrice) : 1000;
+    const configuredProductsPerPage = Number(settings.productsPerPage || process.env.PRODUCTS_PER_PAGE);
+    const resolvedProductsPerPage = Number.isFinite(configuredProductsPerPage) && configuredProductsPerPage > 0 ? configuredProductsPerPage : 24;
+
+    // Default runtimeConfig
+    nuxt.options.runtimeConfig.public.PRIMARY_COLOR = settings.primary_color || '#7F54B2';
+    nuxt.options.runtimeConfig.public.LOGO = settings.logo || '';
+    nuxt.options.runtimeConfig.public.PRODUCTS_PER_PAGE = resolvedProductsPerPage;
+    nuxt.options.runtimeConfig.public.GLOBAL_PRODUCT_ATTRIBUTES = settings.global_attributes || [];
+    nuxt.options.runtimeConfig.public.MAX_PRICE = resolvedMaxPrice;
+    nuxt.options.runtimeConfig.public.FRONT_END_URL = settings.frontEndUrl || '';
+    nuxt.options.runtimeConfig.public.BACKEND_URL = backendUrl;
+    nuxt.options.runtimeConfig.public.CURRENCY_CODE = settings.currencyCode || '';
+    nuxt.options.runtimeConfig.public.CURRENCY_SYMBOL = settings.currencySymbol || '';
+    nuxt.options.runtimeConfig.public.WOO_NUXT_SEO = settings.wooNuxtSEO || [];
+    // Site title
+    process.env.SITE_TITLE = siteTitle;
+
+    // Stripe
+    if (settings.stripeSettings?.enabled) {
+      const stripePublishableKey =
+        settings.stripeSettings?.testmode === 'yes' ? settings.stripeSettings?.test_publishable_key : settings.stripeSettings?.publishable_key;
+      if (stripePublishableKey) nuxt.options.runtimeConfig.public.STRIPE_PUBLISHABLE_KEY = stripePublishableKey;
     }
   },
 });


### PR DESCRIPTION
## Title
Harden first-run store loading without requiring WooNuxt settings plugin

## Summary

This PR improves the initial WooNuxt setup experience for new users by allowing the storefront to boot even when the WooNuxt WordPress settings plugin is not installed yet.

Changes include:

- Makes the WooNuxt settings plugin optional at startup
- Falls back to sensible default runtime config values when plugin settings are unavailable
- Shows a clear non-blocking warning with a link to the latest WooNuxt releases
- Prevents product GraphQL errors from being mislabeled as product 404s
- Fixes product attribute querying for WordPress schemas that expose attributes on `Product`
- Removes a footer hydration warning caused by active link classes
- Adds validation for color filter swatches so invalid color slugs fall back cleanly
