### PR TITLE
Enhancement/minor weaks

### DIFF
--- a/woonuxt_base/app/composables/gql.ts
+++ b/woonuxt_base/app/composables/gql.ts
@@ -185,8 +185,14 @@ export const useAsyncGql = <TMethod extends keyof Sdk>(
   },
 ) => {
   const key = `gql:${String(operation)}:${JSON.stringify(variables ?? {})}`;
-  const gql = useWooGraphQL();
-  const method = gql[operation] as (...args: unknown[]) => Promise<Awaited<ReturnType<Sdk[TMethod]>>>;
 
-  return useAsyncData<Awaited<ReturnType<Sdk[TMethod]>>>(key, () => method(variables, options?.requestHeaders), options?.asyncDataOptions);
+  return useAsyncData<Awaited<ReturnType<Sdk[TMethod]>>>(
+    key,
+    () => {
+      const gql = useWooGraphQL();
+      const method = gql[operation] as (...args: unknown[]) => Promise<Awaited<ReturnType<Sdk[TMethod]>>>;
+      return method(variables, options?.requestHeaders);
+    },
+    options?.asyncDataOptions,
+  );
 };

--- a/woonuxt_base/app/composables/useCountry.ts
+++ b/woonuxt_base/app/composables/useCountry.ts
@@ -6,7 +6,6 @@ export const useCountry = () => {
   // State to store allowed countries
   const allowedCountries = useState<CountriesEnum[] | null>('allowedCountries', () => null);
   const isLoadingAllowedCountries = useState<boolean>('isLoadingAllowedCountries', () => false);
-  const gql = useWooGraphQL();
 
   // State to store the countries to be shown - init with static countries
   const countriesToShow = useState<GeoLocation[]>('countriesToShow', () => countries);
@@ -24,6 +23,7 @@ export const useCountry = () => {
     isLoadingAllowedCountries.value = true;
 
     try {
+      const gql = useWooGraphQL();
       const response = await gql.getAllowedCountries();
       if (response.allowedCountries) {
         // Filter out null values and store the result
@@ -48,6 +48,7 @@ export const useCountry = () => {
     isLoadingCountryStates.value[countryCode] = true;
 
     try {
+      const gql = useWooGraphQL();
       const { countryStates } = await gql.getStates({ country: countryCode });
       if (countryStates) {
         countryStatesDict.value[countryCode] = countryStates as GeoLocation[];

--- a/woonuxt_base/app/composables/useCountry.ts
+++ b/woonuxt_base/app/composables/useCountry.ts
@@ -23,8 +23,8 @@ export const useCountry = () => {
     isLoadingAllowedCountries.value = true;
 
     try {
-      const gql = useWooGraphQL();
-      const response = await gql.getAllowedCountries();
+      const { getAllowedCountries } = useWooGraphQL();
+      const response = await getAllowedCountries();
       if (response.allowedCountries) {
         // Filter out null values and store the result
         allowedCountries.value = response.allowedCountries.filter((country): country is CountriesEnum => country !== null);
@@ -48,8 +48,8 @@ export const useCountry = () => {
     isLoadingCountryStates.value[countryCode] = true;
 
     try {
-      const gql = useWooGraphQL();
-      const { countryStates } = await gql.getStates({ country: countryCode });
+      const { getStates } = useWooGraphQL();
+      const { countryStates } = await getStates({ country: countryCode });
       if (countryStates) {
         countryStatesDict.value[countryCode] = countryStates as GeoLocation[];
       }


### PR DESCRIPTION
This pull request refactors how GraphQL methods are accessed in the composables, aiming to improve code clarity and consistency. The main change is to retrieve individual GraphQL methods directly from `useWooGraphQL()` instead of storing the whole SDK instance, which leads to cleaner and more maintainable code.

**GraphQL method access refactor:**

* In `woonuxt_base/app/composables/gql.ts`, the `useAsyncGql` composable now retrieves the GraphQL method inside the async function, rather than outside, ensuring the latest instance is used.
* In `woonuxt_base/app/composables/useCountry.ts`, the `gql` variable holding the entire GraphQL SDK instance was removed, and instead, individual methods (`getAllowedCountries`, `getStates`) are destructured from `useWooGraphQL()` at the point of use. [[1]](diffhunk://#diff-1e6e49c5e0a014a2876346fac94caf1c2ed30e64b0ccce44bbb3de2407a2c404L9) [[2]](diffhunk://#diff-1e6e49c5e0a014a2876346fac94caf1c2ed30e64b0ccce44bbb3de2407a2c404L27-R27) [[3]](diffhunk://#diff-1e6e49c5e0a014a2876346fac94caf1c2ed30e64b0ccce44bbb3de2407a2c404L51-R52)