### PR TITLE
Chore/upgrade nuxt 4.5 deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Run `npm run graphql:codegen` after changing GraphQL queries or updating the WPG
 | WordPress                    | 7.0.1   |
 | WooCommerce                  | 10.9.4  |
 | WPGraphQL                    | 2.17.0  |
-| WooGraphQL                   | 1.0.2   |
+| WooGraphQL                   | 1.0.3   |
 | ~~WPGraphQL CORS~~           | ~~2.1~~ |
 | Headless Login for WPGraphQL | 0.4.4   |
 | Node                         | 22.22.2 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@stripe/stripe-js": "^9.10.0",
-        "@tailwindcss/postcss": "^4.3.3",
+        "@tailwindcss/vite": "^4.3.3",
         "@vueuse/core": "^14.3.0",
         "graphql": "^16.14.2",
         "graphql-request": "^7.4.0",
@@ -34,18 +34,6 @@
         "prettier": "^3.9.5",
         "typescript": "^6.0.3",
         "vue-tsc": "^3.3.7"
-      }
-    },
-    "node_modules/@alloc/quick-lru": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -1864,7 +1852,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1881,7 +1868,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1898,7 +1884,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1915,7 +1900,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1932,7 +1916,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1949,7 +1932,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1966,7 +1948,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1983,7 +1964,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2000,7 +1980,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2017,7 +1996,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2034,7 +2012,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2051,7 +2028,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2068,7 +2044,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2085,7 +2060,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2102,7 +2076,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2119,7 +2092,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2136,7 +2108,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2153,7 +2124,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2170,7 +2140,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2187,7 +2156,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2204,7 +2172,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2221,7 +2188,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2238,7 +2204,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2255,7 +2220,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2272,7 +2236,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2289,7 +2252,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5737,7 +5699,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -8084,7 +8046,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-alias": {
@@ -9027,19 +8988,6 @@
         "node": ">= 20"
       }
     },
-    "node_modules/@tailwindcss/postcss": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.3.tgz",
-      "integrity": "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==",
-      "license": "MIT",
-      "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.3.3",
-        "@tailwindcss/oxide": "4.3.3",
-        "postcss": "^8.5.16",
-        "tailwindcss": "4.3.3"
-      }
-    },
     "node_modules/@tailwindcss/typography": {
       "version": "0.5.20",
       "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
@@ -9051,6 +8999,20 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+      "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "tailwindcss": "4.3.3"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/@tanstack/virtual-core": {
@@ -9137,7 +9099,7 @@
       "version": "26.1.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -10991,7 +10953,7 @@
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -11788,7 +11750,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/builtin-modules": {
@@ -13477,7 +13439,7 @@
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -14440,7 +14402,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -14699,7 +14660,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -18859,7 +18819,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -20780,7 +20739,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -20799,7 +20758,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -21475,7 +21434,7 @@
       "version": "5.49.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
       "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -21494,7 +21453,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/text-decoder": {
@@ -21548,7 +21507,6 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -21886,7 +21844,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -22483,7 +22441,6 @@
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
       "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
@@ -22807,7 +22764,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -22819,7 +22775,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -22830,7 +22785,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -22841,7 +22795,6 @@
       "version": "0.139.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
       "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -22854,7 +22807,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -22871,7 +22823,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -22888,7 +22839,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -22905,7 +22855,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -22922,7 +22871,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -22939,7 +22887,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -22956,7 +22903,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -22973,7 +22919,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -22990,7 +22935,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -23007,7 +22951,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -23024,7 +22967,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -23041,7 +22983,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -23058,7 +22999,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -23077,7 +23017,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -23094,7 +23033,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -23108,7 +23046,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
       "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.139.0",
@@ -24090,7 +24027,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
       "devDependencies": {
         "@graphql-codegen/add": "^7.1.0",
         "@graphql-codegen/cli": "^7.2.0",
-        "@graphql-codegen/typescript": "^6.1.0",
+        "@graphql-codegen/typescript": "5.0.10",
         "@graphql-codegen/typescript-graphql-request": "^7.1.0",
-        "@graphql-codegen/typescript-operations": "^6.1.1",
+        "@graphql-codegen/typescript-operations": "5.1.0",
         "@iconify-json/ion": "^1.2.7",
         "@nuxt/eslint": "^1.16.0",
         "@nuxt/icon": "^2.3.1",
@@ -2664,6 +2664,70 @@
         }
       }
     },
+    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/schema-ast": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-6.1.0.tgz",
+      "integrity": "sha512-/xuGkM5gUNFRoaQLumKbENdX7Hc8ha49z9OXsEZY8E+46mMjqzXGF0NtCJ892cmoX7EUgI5c8T+LZqS2upx2Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^7.1.0",
+        "@graphql-tools/utils": "^11.2.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/typescript": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-6.1.0.tgz",
+      "integrity": "sha512-2Hu3111O/AwV28Ap7tNsixlmXSAJuQbQArQklx+IC/tNswpckZnCfmlcBtTJrGU1+mJXEneJXGfb2XWvKjbhlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^7.1.0",
+        "@graphql-codegen/schema-ast": "^6.1.0",
+        "@graphql-codegen/visitor-plugin-common": "^7.2.0",
+        "auto-bind": "^5.0.0",
+        "tslib": "~2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/typescript-operations": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-6.1.1.tgz",
+      "integrity": "sha512-mCcG5Sx9kIcWsX/HCgvoqDVN4IqC7ma++BWIhVotf2k8mx15/AHgraUWQvKkPKljUKRPzSLbsj3k3rdnAhWquQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^7.1.0",
+        "@graphql-codegen/schema-ast": "^6.1.0",
+        "@graphql-codegen/visitor-plugin-common": "^7.2.1",
+        "auto-bind": "^5.0.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0",
+        "graphql-sock": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-sock": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@graphql-codegen/core": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-6.2.0.tgz",
@@ -2724,21 +2788,101 @@
       }
     },
     "node_modules/@graphql-codegen/schema-ast": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-6.1.0.tgz",
-      "integrity": "sha512-/xuGkM5gUNFRoaQLumKbENdX7Hc8ha49z9OXsEZY8E+46mMjqzXGF0NtCJ892cmoX7EUgI5c8T+LZqS2upx2Aw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-5.0.2.tgz",
+      "integrity": "sha512-jl1F/9IjRkJisEb9B0ayG4QGqYlPldLRy8ojDdmL9NE1NsdB5ROfxQnSqyC3g+wuvBhWX7kZgMRQYn3RU1I5bA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^7.1.0",
-        "@graphql-tools/utils": "^11.2.0",
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "@graphql-tools/utils": "^11.0.0",
         "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/schema-ast/node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.3.0.tgz",
+      "integrity": "sha512-Auc+/B7okDx9+pVgLVliZtZLYh6iltWXlnzzM+bRE+zh1T4r3hKbnr8xAmtT937ArfSgk5GHcQHr8LfPYnrRBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^11.0.0",
+        "change-case-all": "1.0.15",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/schema-ast/node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@graphql-codegen/schema-ast/node_modules/change-case-all": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.15.tgz",
+      "integrity": "sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "change-case": "^4.1.2",
+        "is-lower-case": "^2.0.2",
+        "is-upper-case": "^2.0.2",
+        "lower-case": "^2.0.2",
+        "lower-case-first": "^2.0.2",
+        "sponge-case": "^1.0.1",
+        "swap-case": "^2.0.2",
+        "title-case": "^3.0.3",
+        "upper-case": "^2.0.2",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/@graphql-codegen/schema-ast/node_modules/sponge-case": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-1.0.1.tgz",
+      "integrity": "sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@graphql-codegen/schema-ast/node_modules/swap-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-2.0.2.tgz",
+      "integrity": "sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/@graphql-codegen/typed-document-node": {
@@ -2762,23 +2906,23 @@
       }
     },
     "node_modules/@graphql-codegen/typescript": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-6.1.0.tgz",
-      "integrity": "sha512-2Hu3111O/AwV28Ap7tNsixlmXSAJuQbQArQklx+IC/tNswpckZnCfmlcBtTJrGU1+mJXEneJXGfb2XWvKjbhlQ==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-5.0.10.tgz",
+      "integrity": "sha512-Pa8OFmL9TdhEYnLYJLYA9EhP8eEeivP/YDYq4Nb8LQaL7GXm4TGX8zELYaCM9Fu8M3iZb7iQGMt7qc+1lXz8XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^7.1.0",
-        "@graphql-codegen/schema-ast": "^6.1.0",
-        "@graphql-codegen/visitor-plugin-common": "^7.2.0",
-        "auto-bind": "^5.0.0",
-        "tslib": "~2.8.0"
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "@graphql-codegen/schema-ast": "^5.0.2",
+        "@graphql-codegen/visitor-plugin-common": "^6.3.0",
+        "auto-bind": "~4.0.0",
+        "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@graphql-codegen/typescript-graphql-request": {
@@ -2921,29 +3065,265 @@
       }
     },
     "node_modules/@graphql-codegen/typescript-operations": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-6.1.1.tgz",
-      "integrity": "sha512-mCcG5Sx9kIcWsX/HCgvoqDVN4IqC7ma++BWIhVotf2k8mx15/AHgraUWQvKkPKljUKRPzSLbsj3k3rdnAhWquQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-5.1.0.tgz",
+      "integrity": "sha512-JlmjbFl0EnsfMDIYvTE1Q0kAOrntVEZ+ZfBqWTP91g4e0F/TzuwJ/V4tiFmeDf5dx/rf9AK4VkPehIdxu7TYhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^7.1.0",
-        "@graphql-codegen/schema-ast": "^6.1.0",
-        "@graphql-codegen/visitor-plugin-common": "^7.2.1",
-        "auto-bind": "^5.0.0",
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "@graphql-codegen/typescript": "^5.0.10",
+        "@graphql-codegen/visitor-plugin-common": "^6.3.0",
+        "auto-bind": "~4.0.0",
         "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0",
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
         "graphql-sock": "^1.0.0"
       },
       "peerDependenciesMeta": {
         "graphql-sock": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.3.0.tgz",
+      "integrity": "sha512-Auc+/B7okDx9+pVgLVliZtZLYh6iltWXlnzzM+bRE+zh1T4r3hKbnr8xAmtT937ArfSgk5GHcQHr8LfPYnrRBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^11.0.0",
+        "change-case-all": "1.0.15",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/@graphql-codegen/visitor-plugin-common": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-6.3.0.tgz",
+      "integrity": "sha512-vGBoE+4huzZyNhyGSAhXAkdROHlwKxxuziZm4XtP1mxe7nuI+VgyOmXebafLijbmuDsptPXQN0C/htL54O8hrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "@graphql-tools/optimize": "^2.0.0",
+        "@graphql-tools/relay-operation-optimizer": "^7.1.1",
+        "@graphql-tools/utils": "^11.0.0",
+        "auto-bind": "~4.0.0",
+        "change-case-all": "1.0.15",
+        "dependency-graph": "^1.0.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/auto-bind": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
+      "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/change-case-all": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.15.tgz",
+      "integrity": "sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "change-case": "^4.1.2",
+        "is-lower-case": "^2.0.2",
+        "is-upper-case": "^2.0.2",
+        "lower-case": "^2.0.2",
+        "lower-case-first": "^2.0.2",
+        "sponge-case": "^1.0.1",
+        "swap-case": "^2.0.2",
+        "title-case": "^3.0.3",
+        "upper-case": "^2.0.2",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/sponge-case": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-1.0.1.tgz",
+      "integrity": "sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/swap-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-2.0.2.tgz",
+      "integrity": "sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.3.0.tgz",
+      "integrity": "sha512-Auc+/B7okDx9+pVgLVliZtZLYh6iltWXlnzzM+bRE+zh1T4r3hKbnr8xAmtT937ArfSgk5GHcQHr8LfPYnrRBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^11.0.0",
+        "change-case-all": "1.0.15",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/@graphql-codegen/visitor-plugin-common": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-6.3.0.tgz",
+      "integrity": "sha512-vGBoE+4huzZyNhyGSAhXAkdROHlwKxxuziZm4XtP1mxe7nuI+VgyOmXebafLijbmuDsptPXQN0C/htL54O8hrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "@graphql-tools/optimize": "^2.0.0",
+        "@graphql-tools/relay-operation-optimizer": "^7.1.1",
+        "@graphql-tools/utils": "^11.0.0",
+        "auto-bind": "~4.0.0",
+        "change-case-all": "1.0.15",
+        "dependency-graph": "^1.0.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/auto-bind": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
+      "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/change-case-all": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.15.tgz",
+      "integrity": "sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "change-case": "^4.1.2",
+        "is-lower-case": "^2.0.2",
+        "is-upper-case": "^2.0.2",
+        "lower-case": "^2.0.2",
+        "lower-case-first": "^2.0.2",
+        "sponge-case": "^1.0.1",
+        "swap-case": "^2.0.2",
+        "title-case": "^3.0.3",
+        "upper-case": "^2.0.2",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/sponge-case": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-1.0.1.tgz",
+      "integrity": "sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/swap-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-2.0.2.tgz",
+      "integrity": "sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/@graphql-codegen/visitor-plugin-common": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "woonuxt",
       "hasInstallScript": true,
       "dependencies": {
-        "@stripe/stripe-js": "^9.10.0",
+        "@stripe/stripe-js": "^9.12.0",
         "@tailwindcss/vite": "^4.3.3",
         "@vueuse/core": "^14.3.0",
         "graphql": "^16.14.2",
@@ -5924,36 +5924,12 @@
         }
       }
     },
-    "node_modules/@nuxt/cli/node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@nuxt/cli/node_modules/citty": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
       "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@nuxt/cli/node_modules/commander": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=22.12.0"
-      }
     },
     "node_modules/@nuxt/cli/node_modules/semver": {
       "version": "7.8.5",
@@ -8694,9 +8670,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/@stripe/stripe-js": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.10.0.tgz",
-      "integrity": "sha512-rxkKgWLAWtjvJhqEynPJ5zPXoKx5cK4eIUunnMGxwUJDRHKv3MlpA1mCCXdeiXzui5YZNWJKUJBTpe7m30jhOA==",
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.12.0.tgz",
+      "integrity": "sha512-wCUYZNYo7E/6B3Rv2i/g/Rmj2mTiOX6HEwWYUWUuNUKwEhzTo/SXuQ1IoNo3mknWIHUQyqdakv1Nl2SiYPrCrw==",
       "license": "MIT",
       "engines": {
         "node": ">=12.16"
@@ -10384,23 +10360,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/@vitejs/devtools-kit/node_modules/crossws": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.10.tgz",
-      "integrity": "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "srvx": ">=0.11.5"
-      },
-      "peerDependenciesMeta": {
-        "srvx": {
-          "optional": true
-        }
       }
     },
     "node_modules/@vitejs/devtools-kit/node_modules/devframe": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,21 +7,21 @@
       "name": "woonuxt",
       "hasInstallScript": true,
       "dependencies": {
-        "@stripe/stripe-js": "^9.9.0",
-        "@tailwindcss/postcss": "^4.3.2",
+        "@stripe/stripe-js": "^9.10.0",
+        "@tailwindcss/postcss": "^4.3.3",
         "@vueuse/core": "^14.3.0",
         "graphql": "^16.14.2",
         "graphql-request": "^7.4.0",
         "reka-ui": "^2.10.1",
         "tailwind-merge": "^3.6.0",
-        "tailwindcss": "^4.3.2"
+        "tailwindcss": "^4.3.3"
       },
       "devDependencies": {
         "@graphql-codegen/add": "^7.1.0",
         "@graphql-codegen/cli": "^7.2.0",
         "@graphql-codegen/typescript": "^6.1.0",
         "@graphql-codegen/typescript-graphql-request": "^7.1.0",
-        "@graphql-codegen/typescript-operations": "^6.1.0",
+        "@graphql-codegen/typescript-operations": "^6.1.1",
         "@iconify-json/ion": "^1.2.7",
         "@nuxt/eslint": "^1.16.0",
         "@nuxt/icon": "^2.3.1",
@@ -30,7 +30,7 @@
         "@tailwindcss/typography": "^0.5.20",
         "@vite-pwa/nuxt": "^1.1.1",
         "eslint": "^10.7.0",
-        "nuxt": "^4.4.8",
+        "nuxt": "^4.5.0",
         "prettier": "^3.9.5",
         "typescript": "^6.0.3",
         "vue-tsc": "^3.3.7"
@@ -82,14 +82,14 @@
       }
     },
     "node_modules/@ardatan/relay-compiler": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/@ardatan/relay-compiler/-/relay-compiler-13.0.1.tgz",
-      "integrity": "sha512-afG3YPwuSA0E5foouZusz5GlXKs74dObv4cuWyLyfKsYFj2r7oGRNB28v18HvwuLSQtQFCi+DpIe0TZkgQDYyg==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@ardatan/relay-compiler/-/relay-compiler-13.0.2.tgz",
+      "integrity": "sha512-VFpv9UP820SiwDUPYtq7PmD3jifzZlevkQ26bhbSzFeruSTys0eHzQCZyKg+IhgmZzwPI9AFjPe26ABNjGeIKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "immutable": "^5.1.5",
+        "@babel/runtime": "^8.0.0",
+        "immutable": "^5.1.9",
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
@@ -1630,14 +1630,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-8.0.0.tgz",
+      "integrity": "sha512-sL6cvO2IfkSu/iU+zs2S/w01B7A8V7suXSIKEN4hPFFdZoiPGxrj5pAG0lCaqLWiEIrjKzdznIWuaLcxPR53qw==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
+      "license": "MIT"
     },
     "node_modules/@babel/template": {
       "version": "7.29.7",
@@ -1687,9 +1684,9 @@
       }
     },
     "node_modules/@clack/core": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.1.tgz",
-      "integrity": "sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.3.tgz",
+      "integrity": "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1701,13 +1698,13 @@
       }
     },
     "node_modules/@clack/prompts": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.5.1.tgz",
-      "integrity": "sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.7.0.tgz",
+      "integrity": "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@clack/core": "1.4.1",
+        "@clack/core": "1.4.3",
         "fast-string-width": "^3.0.2",
         "fast-wrap-ansi": "^0.2.0",
         "sisteransi": "^1.0.5"
@@ -1727,32 +1724,28 @@
       }
     },
     "node_modules/@colordx/core": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.4.3.tgz",
-      "integrity": "sha512-kIxYSfA5T8HXjav55UaaH/o/cKivF6jCCGIb8eqtcsfI46wsvlSiT8jMDyrl779qLec3c2c2oHBZo4oAhvbjrQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.5.0.tgz",
+      "integrity": "sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@dxup/nuxt": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@dxup/nuxt/-/nuxt-0.4.1.tgz",
-      "integrity": "sha512-gtYffW6OfWNvoLW+XD3Mx/K8uUq08PMGLYJoDxc92EzZAWqR0FhcR5iaLm5r/OxyGTKz+P5f5Y7Aoir9+SjYaw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@dxup/nuxt/-/nuxt-0.5.3.tgz",
+      "integrity": "sha512-PRwX3kEDjZF4t+j+lWbhFSZ1WBklwFSus5byNtkCL2PgWoUMbywNtewJcUHVSOQdwEYsbD1H/md3e/CKaTvDyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@dxup/unimport": "^0.1.2",
-        "@nuxt/kit": "^4.4.2",
+        "@nuxt/kit": "^4.4.8",
+        "@vue/compiler-dom": "^3.5.39",
         "chokidar": "^5.0.0",
+        "knitwork": "^1.3.0",
+        "magic-string": "^0.30.21",
         "pathe": "^2.0.3",
-        "tinyglobby": "^0.2.16"
-      },
-      "peerDependencies": {
-        "typescript": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "tinyglobby": "^0.2.17",
+        "unplugin": "^3.3.0"
       }
     },
     "node_modules/@dxup/unimport": {
@@ -1838,9 +1831,9 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.87.0.tgz",
-      "integrity": "sha512-mFXZloZMzuJZXSHUmAFu/pXTk0ZJTJBluuAkrvbzidpTN8W6F2bpRFuedSH+85kbdlRLJqc+gfN+kD3JOLJK5g==",
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.88.0.tgz",
+      "integrity": "sha512-GK/HL/claLLNo5KG705auIlZMwEtmn88ofSGuLsmVZwKBqMPJhW9DiznYNq07QEqz9BPtA3LBfYImtZmhVvRAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2385,16 +2378,16 @@
       }
     },
     "node_modules/@eslint/config-inspector": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@eslint/config-inspector/-/config-inspector-3.0.4.tgz",
-      "integrity": "sha512-qyb1cjiiwD2mlg5GJC4JiO/EOO/rvEtm+GgLtgJ054bu8ZPj6hK1PLCRzxOnBghlPKWVqSjs4i+fXoPkt488Yw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-inspector/-/config-inspector-3.1.0.tgz",
+      "integrity": "sha512-miBAPkS/jN/c5RG/aEYhQaS64wlLXeo2EXXQ2w3SdCWux5icdrHyXnZyiF9dW8TukLURqK6xgzyIdgE1uGx5Vg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "ansis": "^4.3.0",
+        "ansis": "^4.3.1",
         "cac": "^7.0.0",
         "chokidar": "^5.0.0",
-        "devframe": "^0.5.2",
+        "devframe": "^0.6.0",
         "jiti": "^2.7.0",
         "tinyglobby": "^0.2.16"
       },
@@ -2496,28 +2489,28 @@
       "license": "MIT"
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.5",
-        "@floating-ui/utils": "^0.2.11"
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "license": "MIT"
     },
     "node_modules/@floating-ui/vue": {
@@ -2928,15 +2921,15 @@
       }
     },
     "node_modules/@graphql-codegen/typescript-operations": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-6.1.0.tgz",
-      "integrity": "sha512-zv0ohBJqLP1G/Kgiq1MhLTdNmakChtJivpaMaBmuPz9gasKWJkc9MhxuVytF6xS27PkJOh81TNM9srAkqpdejA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-6.1.1.tgz",
+      "integrity": "sha512-mCcG5Sx9kIcWsX/HCgvoqDVN4IqC7ma++BWIhVotf2k8mx15/AHgraUWQvKkPKljUKRPzSLbsj3k3rdnAhWquQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^7.1.0",
         "@graphql-codegen/schema-ast": "^6.1.0",
-        "@graphql-codegen/visitor-plugin-common": "^7.2.0",
+        "@graphql-codegen/visitor-plugin-common": "^7.2.1",
         "auto-bind": "^5.0.0",
         "tslib": "^2.8.0"
       },
@@ -2954,9 +2947,9 @@
       }
     },
     "node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.2.0.tgz",
-      "integrity": "sha512-qqtTY8taONuxlR0HvD8z+zgWC3CfJ47M2rATx+geWNIN8v8Itc5TflHYxjkWAtNL6E3q7WZRY5P7se+2S3EjBg==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.2.1.tgz",
+      "integrity": "sha512-OfTs7yvdbG3LaDJ158vtlglF0QzRN6b/t2Xi02DqBDfJqUorUM72uzuG9BpeALTPNTxFU7aaauS57uTc5oJjsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2989,13 +2982,13 @@
       }
     },
     "node_modules/@graphql-tools/apollo-engine-loader": {
-      "version": "8.0.30",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-8.0.30.tgz",
-      "integrity": "sha512-hUydKGGECrWloERMmfoMzHZi12X99AM9geCGF5XVsv4iMRl/Iyuet24th4kC9bZ8MlAdCwAwtUsCyv9uRfYwSA==",
+      "version": "8.0.34",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-8.0.34.tgz",
+      "integrity": "sha512-pxmrIbUtpiH2/Dx0093EQ0x7dXWdlfAZ97uSY280CkUxIB8EYZeNeV2pvk6HksZzBtHrprLRysrjnegLOmQBRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^11.1.0",
+        "@graphql-tools/utils": "^11.2.2",
         "@whatwg-node/fetch": "^0.10.13",
         "sync-fetch": "0.6.0",
         "tslib": "^2.4.0"
@@ -3008,9 +3001,9 @@
       }
     },
     "node_modules/@graphql-tools/batch-execute": {
-      "version": "10.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-10.0.8.tgz",
-      "integrity": "sha512-Kobt37qrVTFhX4HUK5/vPgMXFw/5f97AzmAlfmDBSRh/GnoAmLKCb48FrEI3gdeIwZB2fEhVHJyDqsojldnLQA==",
+      "version": "10.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-10.0.9.tgz",
+      "integrity": "sha512-khIgAPlyaWJ3dVX6SsqOkABZCH1Gii32WHn3xMzavupsxPCfb/9G3zjdswptzTFrOcZ92dWo7MXvwNFkRfNN4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3027,14 +3020,14 @@
       }
     },
     "node_modules/@graphql-tools/code-file-loader": {
-      "version": "8.1.32",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-8.1.32.tgz",
-      "integrity": "sha512-gR5mNQjn0BugDL8a4A+ovS2KEvU52RNOGnbwiq9oWAEHiSv7iqJu77bpWARTzlE1ZFPK5MSQe9218+1t5PbXmQ==",
+      "version": "8.1.36",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-8.1.36.tgz",
+      "integrity": "sha512-EAIogV/vUmcrNa4icqnx5Xr5z3uLNSZ6867DEJyizuUfOCnD5JzCBQNsBjOBl3R5rzUiV3+GGSzzo15/jLN4oQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/graphql-tag-pluck": "8.3.31",
-        "@graphql-tools/utils": "^11.1.0",
+        "@graphql-tools/graphql-tag-pluck": "8.3.35",
+        "@graphql-tools/utils": "^11.2.2",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
@@ -3047,13 +3040,13 @@
       }
     },
     "node_modules/@graphql-tools/delegate": {
-      "version": "12.0.17",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-12.0.17.tgz",
-      "integrity": "sha512-pIVszWEm69rF+bkM0jUyM1KdIxGzygQbIp1GtV1CuEGRB8lN1uFY1eeTzM2nudHXg8cj+XSVO8cnRpph+o8Dmg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-12.1.0.tgz",
+      "integrity": "sha512-g1vDjYKzPwqnnxcBxwVUdAUqCZdx995RFtoyyy2CNzjXBxUOAZHgw/F2LKXhwnVWdtTsT20bb8hPqUIuNmetDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/batch-execute": "^10.0.8",
+        "@graphql-tools/batch-execute": "^10.0.9",
         "@graphql-tools/executor": "^1.4.13",
         "@graphql-tools/schema": "^10.0.29",
         "@graphql-tools/utils": "^11.0.0",
@@ -3087,15 +3080,15 @@
       }
     },
     "node_modules/@graphql-tools/executor": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.5.3.tgz",
-      "integrity": "sha512-mgBFC0bsrZPZLu9EnydpMnAuQ8Iiq0CEbUcsmvXsm2/iYektGHDN/+bmb7hicA6dWZtdPfklYJmr21WD0GnOfA==",
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.5.7.tgz",
+      "integrity": "sha512-UcXVClkBml+qyGEsQxfEaAkboqySVGFUd9ivn7pDc9jZSckgF6zL21cNxuRH5ZA2exneV3PTtcc0I0rDOdE0Tg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^11.1.0",
+        "@graphql-tools/utils": "^11.2.2",
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@repeaterjs/repeater": "^3.0.4",
+        "@repeaterjs/repeater": "^3.1.0",
         "@whatwg-node/disposablestack": "^0.0.6",
         "@whatwg-node/promise-helpers": "^1.0.0",
         "tslib": "^2.4.0"
@@ -3171,17 +3164,17 @@
       }
     },
     "node_modules/@graphql-tools/executor-legacy-ws": {
-      "version": "1.1.28",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.1.28.tgz",
-      "integrity": "sha512-O4uj93GG9iUb3s32eyhUohvyfA8mLhN8FvGzEdK628hFQPhZN75yurtVFrR08DHex71mQ3wYCCFkErpwdJbDDQ==",
+      "version": "1.1.32",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.1.32.tgz",
+      "integrity": "sha512-rmSp846dAgEGtwdQ7ntdgpLJzzRvw5rE8sR7ASPci2QoIn3McxVYwjq52SMNntoH4VaBeI/BrpyQIN5L68zAfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^11.1.0",
+        "@graphql-tools/utils": "^11.2.2",
         "@types/ws": "^8.0.0",
         "isomorphic-ws": "^5.0.0",
         "tslib": "^2.4.0",
-        "ws": "^8.20.0"
+        "ws": "^8.21.1"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -3191,14 +3184,14 @@
       }
     },
     "node_modules/@graphql-tools/git-loader": {
-      "version": "8.0.36",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-8.0.36.tgz",
-      "integrity": "sha512-PDDakesRu8FJYHJLf9/gkTweh8M19Bymz9i+vOlk9OTs9XmNcCqKM+1S610KX2AodvuBFz/xbesjTtTJIppLPg==",
+      "version": "8.0.40",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-8.0.40.tgz",
+      "integrity": "sha512-aQkcTTymjeQBREoH8/x5JZWt/banq9D7fs8Gqqd2HGirh8JBYGoEbKm45bSdUqCLnqsOJ2oal5A73rsC7ASASw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/graphql-tag-pluck": "8.3.31",
-        "@graphql-tools/utils": "^11.1.0",
+        "@graphql-tools/graphql-tag-pluck": "8.3.35",
+        "@graphql-tools/utils": "^11.2.2",
         "is-glob": "4.0.3",
         "micromatch": "^4.0.8",
         "tslib": "^2.4.0",
@@ -3212,15 +3205,15 @@
       }
     },
     "node_modules/@graphql-tools/github-loader": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-9.1.2.tgz",
-      "integrity": "sha512-jhRJncj9Wkr1Cd8Mo3QI2oG6fTw5ILr1/OXcHIqx744NBj8pPwQBXmQzZqh7MXxbekl2EAcum7SJIjq1HpYcPA==",
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-9.1.6.tgz",
+      "integrity": "sha512-hWsCcTZJ5NLKDUYynZjK7kVh/xmc/MpnLkBII+WQHCLOOXimaESZRnUuoo/nMqOwBKghBC0iF1nHiG9PqD9t3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/executor-http": "^3.2.1",
-        "@graphql-tools/graphql-tag-pluck": "^8.3.31",
-        "@graphql-tools/utils": "^11.1.0",
+        "@graphql-tools/executor-http": "^3.3.0",
+        "@graphql-tools/graphql-tag-pluck": "^8.3.35",
+        "@graphql-tools/utils": "^11.2.2",
         "@whatwg-node/fetch": "^0.10.13",
         "@whatwg-node/promise-helpers": "^1.0.0",
         "sync-fetch": "0.6.0",
@@ -3234,14 +3227,14 @@
       }
     },
     "node_modules/@graphql-tools/graphql-file-loader": {
-      "version": "8.1.14",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.1.14.tgz",
-      "integrity": "sha512-CfAcsSEVkkHfEXLFzrd5rUYpcQEGWNV8lfc1Tb1p5m9HnYICzDDH08I5V33iMrEDza3GuujjjRBYqplBkqwIow==",
+      "version": "8.1.18",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.1.18.tgz",
+      "integrity": "sha512-MBbAPFfGZN+jaRQQkqfY1Ztj4ftFgk9m7zh0h1jQC83xsVJ8zvMk2TGwg7g3lEGqa0cLOOEp/a1/78MSdhj2Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/import": "^7.1.14",
-        "@graphql-tools/utils": "^11.1.0",
+        "@graphql-tools/import": "^7.1.18",
+        "@graphql-tools/utils": "^11.2.2",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
@@ -3254,18 +3247,18 @@
       }
     },
     "node_modules/@graphql-tools/graphql-tag-pluck": {
-      "version": "8.3.31",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.31.tgz",
-      "integrity": "sha512-ema2RRPZGj8TKruNElyDBHVCNFMxioGIVfLBuiA+GdfmRGt95b/i7Uksnj4EwItA6MCmhxokxZoa/fl6mJt3tw==",
+      "version": "8.3.35",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.35.tgz",
+      "integrity": "sha512-k6udGhRFzf/FnfV/pl+2dxVURHtqdOj8evG3xFJahMS9bSMLkmTRCqTaR8e+ErYZEUODE2zCSPth3JLQEfAEqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.6",
-        "@babel/parser": "^7.29.2",
+        "@babel/core": "^7.29.7",
+        "@babel/parser": "^7.29.3",
         "@babel/plugin-syntax-import-assertions": "^7.26.0",
         "@babel/traverse": "^7.26.10",
         "@babel/types": "^7.26.10",
-        "@graphql-tools/utils": "^11.1.0",
+        "@graphql-tools/utils": "^11.2.2",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -3276,13 +3269,13 @@
       }
     },
     "node_modules/@graphql-tools/import": {
-      "version": "7.1.14",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-7.1.14.tgz",
-      "integrity": "sha512-aqLcu04aEidszbXM6M0PWWL8bP17eX9sxXwjYWpglLvIRd4NFqb3C9QzBY8pleqXNMtWqXktlm9BQjevgSrirQ==",
+      "version": "7.1.18",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-7.1.18.tgz",
+      "integrity": "sha512-/lCEk28rbUiypbX8jl5x0RBiHDsXk3YJ5jAU1nlqXEdxNiNI6p5ts+vt0N7UximIuolwV7BeRxLn5RUejyKZYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^11.1.0",
+        "@graphql-tools/utils": "^11.2.2",
         "resolve-from": "5.0.0",
         "tslib": "^2.4.0"
       },
@@ -3294,13 +3287,13 @@
       }
     },
     "node_modules/@graphql-tools/json-file-loader": {
-      "version": "8.0.28",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.28.tgz",
-      "integrity": "sha512-qgCsSkPArnjlNkcYpgGKiXxCTNkrAT9E+l1LhR+Por2jTlKBBeZ8stortkQ/PNDDjuL0WPrLQmHKhNPHabnB3A==",
+      "version": "8.0.32",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.32.tgz",
+      "integrity": "sha512-PJ06nGC836vWWLCAPignLKAnIF+CKNkXlCIe9zkkb02jFPNdG5nA0PUxa1rqt/lqZd/x/ravZQ4yM47pxtLajg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^11.1.0",
+        "@graphql-tools/utils": "^11.2.2",
         "globby": "^11.0.3",
         "tslib": "^2.4.0",
         "unixify": "^1.0.0"
@@ -3313,14 +3306,14 @@
       }
     },
     "node_modules/@graphql-tools/load": {
-      "version": "8.1.10",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.1.10.tgz",
-      "integrity": "sha512-hjcvfEFtwtc8vGi46wtpmGWadNzfEhzbjqinyFIZuIZPlR4aYdWQtqWtY/RMM4Ew4t1USkMNm6xrqC2TH1vCSA==",
+      "version": "8.1.15",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.1.15.tgz",
+      "integrity": "sha512-QpCve0kf1IxNOWAk99VjS4CEZinQjKAfsgDDRWGUg9+9TqBbvCdsLAQshykHcfueEUPetVRVqqqOIRKo9eJ2xQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/schema": "^10.0.33",
-        "@graphql-tools/utils": "^11.1.0",
+        "@graphql-tools/schema": "^10.0.38",
+        "@graphql-tools/utils": "^11.2.2",
         "p-limit": "3.1.0",
         "tslib": "^2.4.0"
       },
@@ -3332,13 +3325,13 @@
       }
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "9.1.9",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.1.9.tgz",
-      "integrity": "sha512-iHUWNjRHeQRYdgIMIuChThOwoKzA9vrzYeslgfBo5eUYEyHGZCoDPjAavssoYXLwstYt1dZj2J22jSzc2DrN0Q==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.2.2.tgz",
+      "integrity": "sha512-DSLLAztOIQId7QE3m8Ehk5lV+0pjxNSSRDHPzlYQ9E4KJ9AoUMBprC4C+eX3v4srh05S2ujm5/veqAr5yEWFSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^11.1.0",
+        "@graphql-tools/utils": "^11.2.2",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -3365,14 +3358,14 @@
       }
     },
     "node_modules/@graphql-tools/relay-operation-optimizer": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-7.1.4.tgz",
-      "integrity": "sha512-cwOD/GEo/R//1uGCP0/urIxsMFoUgzkJVyMt9BDM2HhQhU6rSgH5l6lFukAFTJyPJVdyeOdYm2i0Jj5vYWbHTw==",
+      "version": "7.1.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-7.1.8.tgz",
+      "integrity": "sha512-s16NYT+66VSLCITBURoGNTwh+YvZRSlW3MtFJC2gsvrHZHf6KpCvIR3Qju4yh0FtCoN7Wg7yOI/JT/UzaMEOwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ardatan/relay-compiler": "^13.0.1",
-        "@graphql-tools/utils": "^11.1.0",
+        "@ardatan/relay-compiler": "^13.0.2",
+        "@graphql-tools/utils": "^11.2.2",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -3383,14 +3376,14 @@
       }
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "10.0.33",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.33.tgz",
-      "integrity": "sha512-O6P3RIftO0jafnSsFAqpjurUuUxJ43s/AdPVLQsBkI6y4Ic/tKm4C1Qm1KKQsCDTOxXPJClh/v3g7k7yLKCFBQ==",
+      "version": "10.0.38",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.38.tgz",
+      "integrity": "sha512-Kckk2/vm+rELJ7ijvFaAn9ouWSVUTD0D4SJIvYF4rKeuQHAfCzE/jzMFonZVpTXleqJjPXLZjVbuaMorw7A5Og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/merge": "^9.1.9",
-        "@graphql-tools/utils": "^11.1.0",
+        "@graphql-tools/merge": "^9.2.2",
+        "@graphql-tools/utils": "^11.2.2",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -3401,16 +3394,16 @@
       }
     },
     "node_modules/@graphql-tools/url-loader": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-9.1.2.tgz",
-      "integrity": "sha512-pVSiPrfWQKb3jq23Pl7EjbB2uv3tgZLnWo/axkmg4itAEZ5s/vV/jKa8P1HZzUnSVUTR+8tcEZVeNsUbzFCbkg==",
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-9.1.6.tgz",
+      "integrity": "sha512-BUFafQJv1OVZ/pZvzqXx4oLi2SKeqiWUAIDgz9HGRF/UpJuLY98tYMFzxhYurXg7lAuJMrDjUfl2nFSCX743Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/executor-graphql-ws": "^3.1.4",
-        "@graphql-tools/executor-http": "^3.2.1",
-        "@graphql-tools/executor-legacy-ws": "^1.1.28",
-        "@graphql-tools/utils": "^11.1.0",
+        "@graphql-tools/executor-http": "^3.3.0",
+        "@graphql-tools/executor-legacy-ws": "^1.1.32",
+        "@graphql-tools/utils": "^11.2.2",
         "@graphql-tools/wrap": "^11.1.1",
         "@types/ws": "^8.0.0",
         "@whatwg-node/fetch": "^0.10.13",
@@ -3418,7 +3411,7 @@
         "isomorphic-ws": "^5.0.0",
         "sync-fetch": "0.6.0",
         "tslib": "^2.4.0",
-        "ws": "^8.20.0"
+        "ws": "^8.21.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3428,9 +3421,9 @@
       }
     },
     "node_modules/@graphql-tools/utils": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.2.tgz",
+      "integrity": "sha512-Do2A/t6ayqOma8m7PvpYMsCBswL+NB35BQSng4GWSBqafL2/BnfAZy/NSENPwV721Rm2fG0BHETFC0+FJJZmLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3447,13 +3440,13 @@
       }
     },
     "node_modules/@graphql-tools/wrap": {
-      "version": "11.1.16",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-11.1.16.tgz",
-      "integrity": "sha512-JW1XGFTmltXa537J2bAr8dN/n6EWwiBuM9q8V8mWqZ0eWrf++/TT3/mlV3c0M8B8nrS/lqSsotIwPAtVZR8sWQ==",
+      "version": "11.1.20",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-11.1.20.tgz",
+      "integrity": "sha512-nustNS7MhcyomrhSVJvb5HFjyPtWE+XAH7qBoy1n6zokC6UwFnagyHJFuHKllTz4ONcKw91BdDogHuW9KC3cUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/delegate": "^12.0.17",
+        "@graphql-tools/delegate": "^12.1.0",
         "@graphql-tools/schema": "^10.0.29",
         "@graphql-tools/utils": "^11.0.0",
         "@whatwg-node/promise-helpers": "^1.3.2",
@@ -3552,9 +3545,9 @@
       }
     },
     "node_modules/@iconify/collections": {
-      "version": "1.0.706",
-      "resolved": "https://registry.npmjs.org/@iconify/collections/-/collections-1.0.706.tgz",
-      "integrity": "sha512-S6eOXR2QtzNG9CeTtt/ibkQiBmCwY8489qkHjg52NzYgaVBlUGhlse5FfBck03zhC+/XrtTKfH+pWq1nDaLDnQ==",
+      "version": "1.0.713",
+      "resolved": "https://registry.npmjs.org/@iconify/collections/-/collections-1.0.713.tgz",
+      "integrity": "sha512-IRuFajJYQ/DfU+Dj5ZJwOXmP41UEjao7H77Kn398v6geqqaYGo0DqvatwChssN90Si9V5O/B824r6QHN2MojVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3569,9 +3562,9 @@
       "license": "MIT"
     },
     "node_modules/@iconify/utils": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
-      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4450,9 +4443,9 @@
       }
     },
     "node_modules/@intlify/bundle-utils": {
-      "version": "11.2.3",
-      "resolved": "https://registry.npmjs.org/@intlify/bundle-utils/-/bundle-utils-11.2.3.tgz",
-      "integrity": "sha512-9mrJyUJGPFJCIFGthvIFT58CknG701z9D0VRtLBtat3teo0fisP3Q6bo/t9YHnljBTEZ42hYm1ukn16LfLkRRg==",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/@intlify/bundle-utils/-/bundle-utils-11.2.4.tgz",
+      "integrity": "sha512-eE18yR9eM9k5n8snCkHIYp2MuVTxa19aF8z9OMyxXWv0frz2HlBZDGIPFjA38pP3OJ1IlRBXC/dW5GILeLMSCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4963,14 +4956,14 @@
       }
     },
     "node_modules/@intlify/core": {
-      "version": "11.4.5",
-      "resolved": "https://registry.npmjs.org/@intlify/core/-/core-11.4.5.tgz",
-      "integrity": "sha512-aA17hLi0mJOAR/RNG1CiN0qywuV7jnctjOm0o5bYZ2dZTOTKEGJdfuMxDQJ/MioK6w8ZHMJ1h/lENBfmgLD+ew==",
+      "version": "11.4.7",
+      "resolved": "https://registry.npmjs.org/@intlify/core/-/core-11.4.7.tgz",
+      "integrity": "sha512-ylpfD/nkQYdeROGrnG9Di2js3fCx0UFrWTuiEJljHO3jEJ1Z9ozg+MexK6jZZKEGJLFjb1204q8FVyi9zdzwDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@intlify/core-base": "11.4.5",
-        "@intlify/shared": "11.4.5"
+        "@intlify/core-base": "11.4.7",
+        "@intlify/shared": "11.4.7"
       },
       "engines": {
         "node": ">= 22"
@@ -4980,15 +4973,15 @@
       }
     },
     "node_modules/@intlify/core-base": {
-      "version": "11.4.5",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.4.5.tgz",
-      "integrity": "sha512-lja3F/iKVIvTa48mIwmrIeDcQUFZ0F0drvFvT8AwINOvbwnAzl/S/p8p2DxILZpWEUHRi1qewfWNIkMvhD3kKA==",
+      "version": "11.4.7",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.4.7.tgz",
+      "integrity": "sha512-MSB/sBKwEWJTILvQIhg2rnIcwPpLayo3wGwvVA+dJTNeUBD9GoqQgAaSOLdI9iOPDHCm9YoVnLqpfzza98MpkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@intlify/devtools-types": "11.4.5",
-        "@intlify/message-compiler": "11.4.5",
-        "@intlify/shared": "11.4.5"
+        "@intlify/devtools-types": "11.4.7",
+        "@intlify/message-compiler": "11.4.7",
+        "@intlify/shared": "11.4.7"
       },
       "engines": {
         "node": ">= 22"
@@ -4998,14 +4991,14 @@
       }
     },
     "node_modules/@intlify/devtools-types": {
-      "version": "11.4.5",
-      "resolved": "https://registry.npmjs.org/@intlify/devtools-types/-/devtools-types-11.4.5.tgz",
-      "integrity": "sha512-W5vydP9Yq3t82IyWqCM6aR0BTWCZrN5RAwjZEPpH8I2OQWp2RLy03Evh2ANZlSMhcvGAoyDg25k0so85Kwncpw==",
+      "version": "11.4.7",
+      "resolved": "https://registry.npmjs.org/@intlify/devtools-types/-/devtools-types-11.4.7.tgz",
+      "integrity": "sha512-GSz+J+hqH+AEpAHIYya6fSufS30OaMnG39HiZX7DmGKi3+aaLvassCfsXENEc4Wr4m68q2YP0QdMdB3D9UeAXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@intlify/core-base": "11.4.5",
-        "@intlify/shared": "11.4.5"
+        "@intlify/core-base": "11.4.7",
+        "@intlify/shared": "11.4.7"
       },
       "engines": {
         "node": ">= 22"
@@ -5045,13 +5038,13 @@
       }
     },
     "node_modules/@intlify/message-compiler": {
-      "version": "11.4.5",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.4.5.tgz",
-      "integrity": "sha512-IEOZiHtbQopyPc/Dz2M869lOlZYX1SdcniNJwphATDYHhovvIneEKf1EFF37DE7NAABZtza1FNtnwwqZWInfpw==",
+      "version": "11.4.7",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.4.7.tgz",
+      "integrity": "sha512-bHxmh7n94N4N1evADeb7XTkc3jTw6Ki5biMFZVSX6Jmk+iehy8/maeH2XUsBI27rtKIK+Hzc6QnVAKggUwylKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@intlify/shared": "11.4.5",
+        "@intlify/shared": "11.4.7",
         "source-map-js": "^1.0.2"
       },
       "engines": {
@@ -5062,9 +5055,9 @@
       }
     },
     "node_modules/@intlify/shared": {
-      "version": "11.4.5",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.4.5.tgz",
-      "integrity": "sha512-g/i5mtdUa9ia/8BaJ4w6ZRHgAXYQd9XyCaQPRMvsd8d5qmZwkjoTmHrNsI28Q/7I8h+2ijUkI4uEnnMCziKupQ==",
+      "version": "11.4.7",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.4.7.tgz",
+      "integrity": "sha512-OtjPZan3No2OZZFnMUiCVsXC6+j+XRwEywaFDk0AoayAbLuPesyDloXhJZLl9JUl5vHZeQUkYSbEA8VX+CWMjg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5075,14 +5068,14 @@
       }
     },
     "node_modules/@intlify/unplugin-vue-i18n": {
-      "version": "11.2.3",
-      "resolved": "https://registry.npmjs.org/@intlify/unplugin-vue-i18n/-/unplugin-vue-i18n-11.2.3.tgz",
-      "integrity": "sha512-fbPHjOVAkxrPnbhAs6PTNJlfLOJj35ZqYh8CZ9OpeKZiZoulA9lkvrWYP3kfsZ5K/CG9jIHXxpb1/mf5n/mBYA==",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/@intlify/unplugin-vue-i18n/-/unplugin-vue-i18n-11.2.4.tgz",
+      "integrity": "sha512-bY0ZOaVUvWTyvy4bRGCUKw4Brx5uH/ojjVKsZ1aWzY2drFKIJbeP8DpGMD2QZT8aLpZSUsHtiJlRGLQSZenrvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@intlify/bundle-utils": "11.2.3",
+        "@intlify/bundle-utils": "11.2.4",
         "@intlify/shared": "~11.4.2",
         "@intlify/vue-i18n-extensions": "^8.0.0",
         "@rollup/pluginutils": "^5.1.0",
@@ -5427,9 +5420,9 @@
       }
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5454,13 +5447,13 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.2"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -5510,38 +5503,38 @@
       }
     },
     "node_modules/@nuxt/cli": {
-      "version": "3.35.2",
-      "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-3.35.2.tgz",
-      "integrity": "sha512-sCxNnFuYamqippdj+Cj4Nue55yaUvasaneyf2mnowK5/F1TKln/WVqTH18McxQ4baLlIlVapIFovKjJx1L8XMQ==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-3.37.0.tgz",
+      "integrity": "sha512-Zj9NwHjEBzVrgezsgMFjpMhNqwNgROk9DzNi/dyfk1mCbXIRigV11br2xOl0Satek30bmv7oZAfMtCnDe6Ip0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@bomb.sh/tab": "^0.0.15",
-        "@clack/prompts": "^1.3.0",
+        "@bomb.sh/tab": "^0.0.19",
+        "@clack/prompts": "^1.7.0",
         "c12": "^3.3.4",
         "citty": "^0.2.2",
         "confbox": "^0.2.4",
         "consola": "^3.4.2",
         "debug": "^4.4.3",
         "defu": "^6.1.7",
-        "exsolve": "^1.0.8",
-        "fuse.js": "^7.3.0",
+        "exsolve": "^1.1.0",
+        "fuse.js": "^7.4.2",
         "fzf": "^0.5.2",
-        "giget": "^3.2.0",
+        "giget": "^3.3.0",
         "jiti": "^2.7.0",
         "listhen": "^1.10.0",
-        "nypm": "^0.6.6",
+        "nypm": "^0.6.8",
         "ofetch": "^1.5.1",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
         "perfect-debounce": "^2.1.0",
         "pkg-types": "^2.3.1",
         "scule": "^1.3.0",
-        "semver": "^7.8.0",
-        "srvx": "^0.11.15",
-        "std-env": "^4.1.0",
-        "tinyclip": "^0.1.12",
-        "tinyexec": "^1.1.2",
+        "semver": "^7.8.5",
+        "srvx": "^0.11.22",
+        "std-env": "^4.2.0",
+        "tinyclip": "^0.1.15",
+        "tinyexec": "^1.2.4",
         "ufo": "^1.6.4",
         "youch": "^4.1.1"
       },
@@ -5555,7 +5548,7 @@
         "node": "^16.14.0 || >=18.0.0"
       },
       "peerDependencies": {
-        "@nuxt/schema": "^4.4.5"
+        "@nuxt/schema": "^4.4.6"
       },
       "peerDependenciesMeta": {
         "@nuxt/schema": {
@@ -5564,9 +5557,9 @@
       }
     },
     "node_modules/@nuxt/cli/node_modules/@bomb.sh/tab": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@bomb.sh/tab/-/tab-0.0.15.tgz",
-      "integrity": "sha512-Y90ub44TAvbdO9P8mcD/XPyQjFhiR5xmd4Fk7JErmWmEWEUimNnjWiBrVZ16Tj3GA1rLZ+uvCN2V/pzLawv31g==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@bomb.sh/tab/-/tab-0.0.19.tgz",
+      "integrity": "sha512-dTRfo9Q9B+lbLG3JCu8a/AGQSfD2XXcFcnakQzVjSOX+VvR/s9zpsH8TlqV3iHqazniRn1Ypwd1hcRlXcu/4BA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5575,7 +5568,7 @@
       "peerDependencies": {
         "cac": "^6.7.14",
         "citty": "^0.1.6 || ^0.2.0",
-        "commander": "^13.1.0"
+        "commander": "^13.1.0 || ^14.0.0 || ^15.0.0"
       },
       "peerDependenciesMeta": {
         "cac": {
@@ -5609,21 +5602,21 @@
       "license": "MIT"
     },
     "node_modules/@nuxt/cli/node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@nuxt/cli/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5728,9 +5721,9 @@
       }
     },
     "node_modules/@nuxt/devtools-wizard/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5751,9 +5744,9 @@
       }
     },
     "node_modules/@nuxt/devtools/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5923,9 +5916,9 @@
       "license": "MIT"
     },
     "node_modules/@nuxt/kit": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.4.8.tgz",
-      "integrity": "sha512-ZUlZ5iYfyfJFDPluhn6ZxFWcsuxWbLnZBc8w3MAROcQ4lYfZ+qFpALBLSNlpc0zhOa++33EE+5PEbOAdVIY+dw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.0.tgz",
+      "integrity": "sha512-VD4GjRjbh7r7ILoXYbiKeQgZuYP/vJ7iMk6fSRak1+xEyXHpQ+OIq/EfIjfsHv7DVimddOB+I6W/wGXjRVZ+Ng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5934,20 +5927,21 @@
         "defu": "^6.1.7",
         "destr": "^2.0.5",
         "errx": "^0.1.0",
-        "exsolve": "^1.0.8",
-        "ignore": "^7.0.5",
+        "exsolve": "^1.1.0",
+        "ignore": "^7.0.6",
         "jiti": "^2.7.0",
         "klona": "^2.0.6",
         "mlly": "^1.8.2",
+        "nostics": "^1.1.4",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
         "pkg-types": "^2.3.1",
         "rc9": "^3.0.1",
         "scule": "^1.3.0",
-        "semver": "^7.8.1",
+        "semver": "^7.8.5",
         "tinyglobby": "^0.2.17",
         "ufo": "^1.6.4",
-        "unctx": "^2.5.0",
+        "unctx": "^3.0.0",
         "untyped": "^2.0.0"
       },
       "engines": {
@@ -5955,9 +5949,9 @@
       }
     },
     "node_modules/@nuxt/kit/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5968,48 +5962,49 @@
       }
     },
     "node_modules/@nuxt/nitro-server": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/@nuxt/nitro-server/-/nitro-server-4.4.8.tgz",
-      "integrity": "sha512-cc1fxgSx34Htesx3JBO+hMhbqd6VljXDC06P+UOA5z53cR224TmEFYT/MUuZDkrtt4qLnSG8yq0IxhEM3NCUlw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/nitro-server/-/nitro-server-4.5.0.tgz",
+      "integrity": "sha512-XxLtFxBLJkXJ368mzgub7eDMc9I4pwnZhN9gX8UTzajgoEnbxPhmUl7xG8RVBMovQ2FOFjAph2kwJrnlMNX/cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nuxt/devalue": "^2.0.2",
-        "@nuxt/kit": "4.4.8",
-        "@unhead/vue": "^2.1.15",
-        "@vue/shared": "^3.5.35",
+        "@nuxt/kit": "4.5.0",
+        "@unhead/vue": "^3.1.8",
+        "@vue/shared": "^3.5.39",
         "consola": "^3.4.2",
         "defu": "^6.1.7",
         "destr": "^2.0.5",
         "devalue": "^5.8.1",
         "errx": "^0.1.0",
         "escape-string-regexp": "^5.0.0",
-        "exsolve": "^1.0.8",
+        "exsolve": "^1.1.0",
         "h3": "^1.15.11",
         "impound": "^1.1.5",
         "klona": "^2.0.6",
         "mocked-exports": "^0.1.1",
         "nitropack": "^2.13.4",
-        "nypm": "^0.6.6",
+        "nostics": "^1.1.4",
+        "nypm": "^0.6.8",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
-        "rou3": "^0.8.1",
-        "std-env": "^4.1.0",
+        "rou3": "^0.9.1",
+        "std-env": "^4.2.0",
         "ufo": "^1.6.4",
-        "unctx": "^2.5.0",
+        "unctx": "^3.0.0",
         "unstorage": "^1.17.5",
-        "vue": "^3.5.35",
-        "vue-bundle-renderer": "^2.2.0",
+        "vue": "^3.5.39",
+        "vue-bundle-renderer": "^2.3.1",
         "vue-devtools-stub": "^0.1.0"
       },
       "engines": {
-        "node": "^22.12.0 || ^24.11.0 || >=26.0.0"
+        "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@babel/plugin-proposal-decorators": "^7.25.0",
-        "@babel/plugin-syntax-typescript": "^7.25.0",
+        "@babel/plugin-proposal-decorators": "^7.25.0 || ^8.0.0",
+        "@babel/plugin-syntax-typescript": "^7.25.0 || ^8.0.0",
         "@rollup/plugin-babel": "^6.0.0 || ^7.0.0",
-        "nuxt": "^4.4.8"
+        "nuxt": "^4.5.0"
       },
       "peerDependenciesMeta": {
         "@babel/plugin-proposal-decorators": {
@@ -6037,17 +6032,18 @@
       }
     },
     "node_modules/@nuxt/schema": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-4.4.8.tgz",
-      "integrity": "sha512-igfWuMF0x0Pmx/XwhPwH/bcXgbuwNnjUjqxCAsY6VQhmGKo0e9soJq3Q0ohj+rBkBfX6o2ysTP1/t2M82aK4qA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-4.5.0.tgz",
+      "integrity": "sha512-RY4cH0z2JRlmcsAIrBBXlmRW8FnCBTRdHCByttog+lAxg1hrJ2W5OdnoHO0KMeZSJg67MdeYPOZu7ZszFEymgA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "^3.5.35",
+        "@vue/shared": "^3.5.39",
         "defu": "^6.1.7",
+        "nostics": "^1.1.4",
         "pathe": "^2.0.3",
         "pkg-types": "^2.3.1",
-        "std-env": "^4.1.0"
+        "std-env": "^4.2.0"
       },
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
@@ -6091,49 +6087,49 @@
       "license": "MIT"
     },
     "node_modules/@nuxt/vite-builder": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-4.4.8.tgz",
-      "integrity": "sha512-54M/k6qVY85Qeoe1m/lPZ0SANGJEbI50r5uYgh3XT942ENve3K5Nk6TMYp8i5wGGC4TWvPea+1mlCrp8rjsXag==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-4.5.0.tgz",
+      "integrity": "sha512-j57djn164gnTIFMw0ISMMesX6a98H51XKoERm90401Prb4VERq0ULNb8zOXrHgJMGFOy6An7tKo8fD/J7qCLLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nuxt/kit": "4.4.8",
-        "@rollup/plugin-replace": "^6.0.3",
-        "@vitejs/plugin-vue": "^6.0.7",
-        "@vitejs/plugin-vue-jsx": "^5.1.5",
-        "autoprefixer": "^10.5.0",
+        "@nuxt/kit": "4.5.0",
+        "@vitejs/plugin-vue": "^6.0.8",
+        "@vitejs/plugin-vue-jsx": "^5.1.6",
+        "autoprefixer": "^10.5.3",
         "consola": "^3.4.2",
-        "cssnano": "^8.0.1",
+        "cssnano": "^8.0.2",
         "defu": "^6.1.7",
         "escape-string-regexp": "^5.0.0",
-        "exsolve": "^1.0.8",
+        "exsolve": "^1.1.0",
         "get-port-please": "^3.2.0",
         "jiti": "^2.7.0",
+        "js-tokens": "^10.0.0",
         "knitwork": "^1.3.0",
-        "magic-string": "^0.30.21",
         "mlly": "^1.8.2",
         "mocked-exports": "^0.1.1",
-        "nypm": "^0.6.6",
+        "nypm": "^0.6.8",
         "pathe": "^2.0.3",
         "pkg-types": "^2.3.1",
-        "postcss": "^8.5.15",
-        "seroval": "^1.5.4",
-        "std-env": "^4.1.0",
+        "postcss": "^8.5.19",
+        "rolldown-string": "^0.3.0",
+        "seroval": "^1.5.5",
+        "std-env": "^4.2.0",
         "ufo": "^1.6.4",
         "unenv": "^2.0.0-rc.24",
-        "vite": "^7.3.3",
-        "vite-node": "^5.3.0",
-        "vite-plugin-checker": "^0.14.1",
-        "vue-bundle-renderer": "^2.2.0"
+        "vite": "^8.1.4",
+        "vite-node": "^6.0.0",
+        "vite-plugin-checker": "^0.14.4",
+        "vue-bundle-renderer": "^2.3.1"
       },
       "engines": {
-        "node": "^22.12.0 || ^24.11.0 || >=26.0.0"
+        "node": "^22.18.0 || ^24.11.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@babel/plugin-proposal-decorators": "^7.25.0",
-        "@babel/plugin-syntax-jsx": "^7.25.0",
-        "nuxt": "4.4.8",
-        "rolldown": "^1.0.0-beta.38",
+        "@babel/plugin-proposal-decorators": "^7.25.0 || ^8.0.0",
+        "@babel/plugin-syntax-jsx": "^7.25.0 || ^8.0.0",
+        "nuxt": "4.5.0",
+        "rolldown": "^1.0.0",
         "rollup-plugin-visualizer": "^6.0.0 || ^7.0.1",
         "vue": "^3.3.4"
       },
@@ -6152,490 +6148,6 @@
         }
       }
     },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
-      }
-    },
     "node_modules/@nuxt/vite-builder/node_modules/escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -6649,80 +6161,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@nuxt/vite-builder/node_modules/vite": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
-      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+    "node_modules/@nuxt/vite-builder/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
+      "license": "MIT"
     },
     "node_modules/@nuxtjs/i18n": {
       "version": "10.4.1",
@@ -6765,349 +6209,7 @@
         "url": "https://github.com/sponsors/bobbiegoede"
       }
     },
-    "node_modules/@oxc-minify/binding-android-arm-eabi": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm-eabi/-/binding-android-arm-eabi-0.133.0.tgz",
-      "integrity": "sha512-D8M1+nqwLaACHZsld/t6f+cE4N97XOu5iQ88f1ZaYH4ptFzFrXo5N7wUKACTI4xmNUD+6W0Y4Apk5U2r8HLdBQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-minify/binding-android-arm64": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm64/-/binding-android-arm64-0.133.0.tgz",
-      "integrity": "sha512-dnQUJdpOEh/nZfQtvGGN61VcCCcPJ2aCm+ndl8GIA2lk2GpmIBgZ9h+phLVhgUFGt2es+2AQc0xvtK7RFNsViw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-minify/binding-darwin-arm64": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-arm64/-/binding-darwin-arm64-0.133.0.tgz",
-      "integrity": "sha512-K6+aXlOlsCcibpTiTitQYNXWGGwea0fEKF/kGHCNB+MNqOLCkdC7wesycaABYcXcyr58DhDoJnVb8E4Hq95iVw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-minify/binding-darwin-x64": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-x64/-/binding-darwin-x64-0.133.0.tgz",
-      "integrity": "sha512-BFEXHxYNwThyaO63p1VE5MOOXNGkHsHfkmajOCKXH40TfllTHQenXhpJ9mHDoF7EhaQjArpPjlDY88BuPjhurw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-minify/binding-freebsd-x64": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-freebsd-x64/-/binding-freebsd-x64-0.133.0.tgz",
-      "integrity": "sha512-oT5dbcXnS/cbpdXCpudAeVg/fqH1XnKhLUE/vkuRTuocjOd/GA2MoNMMhLWUvqNXO0xJnYmo2ISmDxShkItfOQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-minify/binding-linux-arm-gnueabihf": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.133.0.tgz",
-      "integrity": "sha512-tJ3B+b7DOuTsIMXSmu5xHHCakrBqqcrp4COYd/lelOdDvkbFoDRGnwH91POUOSUEOI/WLzIMkDqAH2SZ3N2jhQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-minify/binding-linux-arm-musleabihf": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.133.0.tgz",
-      "integrity": "sha512-XMUHfdilk1KTtOM2vA1bwDso07/wkLm/GgDOO9z/ioxrZoQyjXnJRW665VXa08z2BqEgwHRc1zH9p7s6sKPQbg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-minify/binding-linux-arm64-gnu": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.133.0.tgz",
-      "integrity": "sha512-UEff2jopbwJ4SndmxK06uqXrOpwWiJERJPdgDTBywwXP9QgW0p1YkQnBNt4+jK0I/hdLpbbyaCLLuUPKbaU70w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-minify/binding-linux-arm64-musl": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.133.0.tgz",
-      "integrity": "sha512-yqskeIapQvx7Tu/OLsepLPcGsHGzfYy9PX6gIbhaOHfF+LA2zHBKnKb587FGx+lQjHLQR0llfmoSuXQ6q2EN+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-minify/binding-linux-ppc64-gnu": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.133.0.tgz",
-      "integrity": "sha512-r7PnUNxRB9D/gQjCVeasoieJVUF48n43rvk/jYbGAw9sRfYGoEo/rOs0GyTZU9ttss8HzjBaerAbADbAL8K8vw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-minify/binding-linux-riscv64-gnu": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.133.0.tgz",
-      "integrity": "sha512-omXWC8I9lAMMjQIeadfItP5H4VDAiuU2BiVCtHMH3ktTbFq04sxscZhK4NFUUuw3fApDdXmfd7LW18q0JBHarg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-minify/binding-linux-riscv64-musl": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.133.0.tgz",
-      "integrity": "sha512-LtFA3Hi8LVD/zuiPLKy9Aiz7N1IOj8rRhdXiW38GKQ9mAhj+Ko6IHGcTk2A7yNDA1DZBl7r+Qd4PEGWgVelPPw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-minify/binding-linux-s390x-gnu": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.133.0.tgz",
-      "integrity": "sha512-rFsPDsT1j3beSInbrFukAAlTg101PcqdVMXDioR9AgJ1180tZ8s8D+pNDpQTRmPd3956mnpAE+Cs77Xoo/QZAQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-minify/binding-linux-x64-gnu": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.133.0.tgz",
-      "integrity": "sha512-xlrtAmDWZI8BEmsaXMYfblWuLIY5UnnRkit1VLkmVDb5ceZRZf4oEXK1QeYf5Z33dT0WK1Ek++P+TL/ZMCpyGQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-minify/binding-linux-x64-musl": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-musl/-/binding-linux-x64-musl-0.133.0.tgz",
-      "integrity": "sha512-kd36CDkTkZDMNfVceNTSfpWnitE1+GjZmzJCeq8yaxsgvs/MXg8aauI2RgFjElYZIHSMyZku4pQ7Jtl3ZEYI6w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-minify/binding-openharmony-arm64": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-openharmony-arm64/-/binding-openharmony-arm64-0.133.0.tgz",
-      "integrity": "sha512-pI38dJBqfkNbFoL/GEarAzGDjKGVCZTdg0a8NKh1PP9GqWleXT6HLtXE4CZ+54e+2u68qVYVBwhbWAiRfwlUZA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-minify/binding-wasm32-wasi": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-wasm32-wasi/-/binding-wasm32-wasi-0.133.0.tgz",
-      "integrity": "sha512-AkLr+d+LLY4/55J/TrE0srNBUpZPzyU+cygdse7yZ9AhCndryNqe2y6e8naVK0TV7n8lxBd2OGGJAkho6blAkw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-minify/binding-win32-arm64-msvc": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.133.0.tgz",
-      "integrity": "sha512-V92v7397t2073g+mSfaLHnPeoz6hA/1U4JNLeUBP87eWGZgVxDZ2qz3t3wFyYqXGJ/0VoEwdP8yrHLQQ7QzAOQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-minify/binding-win32-ia32-msvc": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.133.0.tgz",
-      "integrity": "sha512-2DP5RbG/SSaRVtmuwgTH6Ati4+uuOJjoI88dQnC5hD0zCC90EVDXZSXyJQ5i/OxLE1UAy58Wo2DJot/OrUspzA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-minify/binding-win32-x64-msvc": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.133.0.tgz",
-      "integrity": "sha512-PJ75c6PlBx87tau0W35J43eGCv4wrDmdZ+4ddTZAnGtZqEeCVsLdmDPOEMe2DepogqlSVUF2kGBWtnFUJ5c7Rw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-android-arm-eabi": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.128.0.tgz",
       "integrity": "sha512-aca6ZvzmCBUGOANQRiRQRZuRKYI3ENhcit6GisnknOOmcezfQc7xJ4dxlPU7MV7mOvrC7RNR1u3LAD7xyaiCxA==",
@@ -7124,7 +6226,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-android-arm64": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-android-arm64": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.128.0.tgz",
       "integrity": "sha512-BbeDmuohoJ7Rz/it5wnkj69i/OsCPS3Z51nLEzwO/Y6YshtC4JU+15oNwhY8v4LRKRYclRc7ggOikwrsJ/eOEQ==",
@@ -7141,7 +6243,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-darwin-arm64": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-darwin-arm64": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.128.0.tgz",
       "integrity": "sha512-tRUHPt80417QmvNpoSslJT1VY8NUbWdrWR+L14Zn+RbOTcaqB8E6PYE/ZGN8jjWBzqporiA/H4MfO50ew/NCNA==",
@@ -7158,7 +6260,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-darwin-x64": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-darwin-x64": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.128.0.tgz",
       "integrity": "sha512-rWI2Hb1Nt3U/vKsjyNvZzDC8i/l144U20DKjhzaTmwIhIiSRGeroPWWiImwypmKLqrw8GuIixbWJkpGWLbkzrQ==",
@@ -7175,7 +6277,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-freebsd-x64": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-freebsd-x64": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.128.0.tgz",
       "integrity": "sha512-hhpdVMaNCLgQxjgNPeeFzSeJMmZPc5lKfv0NGSI3egZq9EdnEGqeC8JsYsQjK7PoQgbvZ17xlj0SO5ziH5Obkg==",
@@ -7192,7 +6294,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.128.0.tgz",
       "integrity": "sha512-093zNw0zZ/e/obML+rhlSdmnzR0mVZluPcAkxunEc5E3F0yBVsFn24Y1ILfsEte11Ud041qn/gp2OJ1jxNqUng==",
@@ -7209,7 +6311,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.128.0.tgz",
       "integrity": "sha512-fq7DmKmfC+dvD97IXrgbph6Jzwe0EDu+PYMofmzZ6fv5X1k9vtaqLpDGMuICO9MmUnyKAQmVl+wIv2RNy4Dz8g==",
@@ -7226,7 +6328,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-linux-arm64-gnu": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.128.0.tgz",
       "integrity": "sha512-Xvm48jJah8TlIrURIjNOP/gNiGe6aKvCB+r06VliflFo8Kq7VOLE8PxtgShJzZIqubrgdMdYfvuPPozn7F6MbQ==",
@@ -7243,7 +6345,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-linux-arm64-musl": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.128.0.tgz",
       "integrity": "sha512-M7iwBGmYJTx+pKOYFjI0buop4gJvlmcVzFGaXPt21DKpQkbQZG1f63Yg7LloIYT/t9yLxCw0Lhfx/RFlAlMSjA==",
@@ -7260,7 +6362,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.128.0.tgz",
       "integrity": "sha512-21LGNIZb1Pcfk5/EGsqabrxv4yqQOWis1407JJrClS7XpFCrbvr74YAB1V+m54cYbwvO6UWwQqS4WecxiyfCRg==",
@@ -7277,7 +6379,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.128.0.tgz",
       "integrity": "sha512-gyHjOTFpg9bTTYjxPmQirvufb89+VdZwVfcMtAUyPr6F5H8ZswvCQshK4qOW+Q+2Xyb33hduRgY/eFHJQjU/vQ==",
@@ -7294,7 +6396,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-linux-riscv64-musl": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.128.0.tgz",
       "integrity": "sha512-X6Q2oKUrP5GyDd2xniuEBLk6aFQCZ97W2+aVXGgJXdjx5t4/oFuA9ri0wLOUrBIX+qdSuK581snMBio4z910eA==",
@@ -7311,7 +6413,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-linux-s390x-gnu": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.128.0.tgz",
       "integrity": "sha512-BdzTmqxfxoYkpgokoLaSnOX6T+R3/goL42klre2tnG+kHbG2TXS0VN+P5BPofH1axdKOHy5ei4ENZrjmCOt2lA==",
@@ -7328,7 +6430,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-linux-x64-gnu": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.128.0.tgz",
       "integrity": "sha512-OO1nW2Q7sSYYvJZpDHdvyFSdRaVcQqRijZSSmWVMqFxPYy8cEF45zJ9fcdIYuzIT3jYq6YRhEFm/VMWNWhE22Q==",
@@ -7345,7 +6447,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-linux-x64-musl": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.128.0.tgz",
       "integrity": "sha512-4NehAe404MRdoZVS9DW8C5XbJwbXIc/KfVlYdpi5vE4081zc9Y0YzKVqyOYj/Puye7/Do+ohaONBFWlEHYl9hw==",
@@ -7362,7 +6464,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-openharmony-arm64": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.128.0.tgz",
       "integrity": "sha512-kVbqgW9xLL8bh8oc7aYOJilRKXE5G33+tE0jan+duo/9OriaFRpijcCwT2waWs2oqYROYq0GlE7/p3ywoshVeg==",
@@ -7379,7 +6481,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-wasm32-wasi": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.128.0.tgz",
       "integrity": "sha512-L38ojghJYHmgiz6fJd7jwLB/ESDBpB02NdFxh+smqVM6P2anCEvHn0jhaSrt5eVNR1Ak8+moOeftUlofeyvniA==",
@@ -7398,7 +6500,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-win32-arm64-msvc": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.128.0.tgz",
       "integrity": "sha512-xgvO35GyHBtjlQ5AEpaYr7Rll1rvY7zqIhT6ty8E3ezBW2J1SFLjIDEvI/tcgDg6oaseDAqVcM+jU1HuCekgZw==",
@@ -7415,7 +6517,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-win32-ia32-msvc": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.128.0.tgz",
       "integrity": "sha512-OY+3eM2SN72prHKRB22mPz8o5A/7dJ+f5DFLBVvggyZhEaNDAH9IB+ElMjmOkOIwf5MDCUAowCK7pAncNxzpBA==",
@@ -7432,7 +6534,7 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-win32-x64-msvc": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.128.0.tgz",
       "integrity": "sha512-NE9ny+cPUCCObXa0IKLfj0tCdPd7pe/dz9ZpkxpUOymB3miNeMPybdlYYTBSGJUalMWeBM85/4JcCErCNTqOXw==",
@@ -7449,10 +6551,434 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-project/types": {
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-project/types": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
       "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/oxc-parser": {
+      "version": "0.128.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.128.0.tgz",
+      "integrity": "sha512-XkOw3eiIxAgQ19WRew/Bq9wc5Ga/guaWIzDBzq80z1PyuDNGvWBpPby9k6YGwV8A8uMw+Nlq3xqlzuDYmUFYUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.128.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.128.0",
+        "@oxc-parser/binding-android-arm64": "0.128.0",
+        "@oxc-parser/binding-darwin-arm64": "0.128.0",
+        "@oxc-parser/binding-darwin-x64": "0.128.0",
+        "@oxc-parser/binding-freebsd-x64": "0.128.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.128.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.128.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.128.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.128.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.128.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.128.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.128.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.128.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.128.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.128.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.128.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.128.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.128.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.128.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.128.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.140.0.tgz",
+      "integrity": "sha512-ZfjDZ422mo7eo3b3VltqNsV9kmv1qt/sPEAMSl64iOSwhVfd0eIZ9LB79Mbs1xYXJnk7WSROwzBCKDIiVxPTvQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.140.0.tgz",
+      "integrity": "sha512-Ia8jSvikUX6Sf+Ht+KOCUF/k1HpR0VlmqIYymubmWDebOEGtsyliHDR6JxsZ4IX3/c/GbrB1uh09aVGQv/LQmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.140.0.tgz",
+      "integrity": "sha512-G6VK0nK61pH0d0mBjUqSZbVxGqqO5uzeginLDQj+gOO6ObfJjXRwgkD/ol0w1INcnFeAb6YGGO7qc3ueGHaycQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.140.0.tgz",
+      "integrity": "sha512-HazBOuZzd2pO1C2uMmp8Gv7mhzMHqKSKDS1OZfcLEvpIcgA+48J92HEtNanVHDIzRD9PRPCV6aS6fkZIWOVl8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.140.0.tgz",
+      "integrity": "sha512-9hSUU+HmTUyOe4JzMHxNGgLWNY7rrO+6ShicZwImNJacEAACDMIkuEQQkvXSL+WJN50jaNtLYJv8s4OcBdpyUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.140.0.tgz",
+      "integrity": "sha512-RAEuQsYtS0KcDFqN0ABTjyyNlokS91JeuDuoW9tEbG0JTbRNXnpQUdbYc/16JoA6Z/2ALbNrE3KmxtqDiuIjCQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.140.0.tgz",
+      "integrity": "sha512-c4CkHvPvqfojouredJ0w3e6+jiBq0SbFyhH61kr/zPb/7XsaYTNKQ54vmlSsopfdQbNDX40ZeK9Abs2Qet6wcw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.140.0.tgz",
+      "integrity": "sha512-yrjmLj8ixPB25yqvPGr28meGjb+keed7m1GqqY/0uqkhZIoT4t9zmfwUgFEtC33C7dtE+UQ7TU0IaVxf97SWJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.140.0.tgz",
+      "integrity": "sha512-ggGMQTN8Agwxp2WiLMpdY671dt0qTDJWiWlJeig3HnUwTnerRl0J2JdGVghWBeDcss2D9S2V2Js6dZHEiVabVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.140.0.tgz",
+      "integrity": "sha512-IgTs8xYAFgAUGNmR65tIqjlJ8vKgrfXzC515e9goSdfMyKQV4aJpd2pUUudU4u51G64H0/DSEJEXKOraxm9ZCA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.140.0.tgz",
+      "integrity": "sha512-A1x+PMWZmSGaFVOx2YeNTFau8uD+QO14/vLP4GrcuvUPs3+nBkUOjy9Lus86ftHsDojjYMbvBelmKc3F7Rv08g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.140.0.tgz",
+      "integrity": "sha512-zBqpfRo2myWPrPo5xUjeZqlnPXPXsX8BcWtWff66/eGRQdbPjhzPgXa/F+AtxT2afUViPxbuDlwscMKzQ5tg+g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.140.0.tgz",
+      "integrity": "sha512-2M1DPm/8w9I//YzFlFC9qXw+r2tJFh5CYwRlYTq2vUJQS7qoQftEDeCZ8EnN7KHtvSiXvYj8mZI5pR7DpXmcEw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.140.0.tgz",
+      "integrity": "sha512-8aRDbZ/U/jO8N7go1MO72jtbpb4uswV8d7vOkMvt/BPgZiyEYvl1VIWK4ESxZZhnJ4tqwVldgX7dNiP/eB1Jdg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.140.0.tgz",
+      "integrity": "sha512-xRqpeI8U2sQQS1W5BMWRyMTxtagkuLG2dEWruet5lFsWHTvBth11/TpSaJatHdqVVwHN0q3uuoS9zRsGinq8hg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.140.0.tgz",
+      "integrity": "sha512-GbGRe26MqAKciFRvXeHNQJ6VAHYs9R4miP89sEAncysM3n+f4lnyLWgsa9kklJNpfnxdq2yRoNYHFqwBckVimw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.140.0.tgz",
+      "integrity": "sha512-vFiC1hqys+hkX1GnQkIoiTQJNiUm43Z0lO35ETKXTw0YtpW7+cN58YRRXFAQQ+TgpkIi3lrhcxdlnqz+Oi3ptQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.2",
+        "@emnapi/runtime": "1.11.2",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.140.0.tgz",
+      "integrity": "sha512-fGSQldwEYKhM+H8uLt76Op8hh5+FYaR6lvvQ1Txw3Mhn86DyQXLcI0fi1EkFlTK7F+46OCk/j0AJMzZQm6g5Xg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.140.0.tgz",
+      "integrity": "sha512-sDS2Bai+g3ZWYwfZqmosiSuFDBcVnZ3Ta6pszzsiJoLMqsJEWKcxXXbGa7b7yXr++W2lQNPb3ZRJ8czseqL7RA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.140.0.tgz",
+      "integrity": "sha512-kHbE1zWyb5OQgJA6/5P4WjiuB01sYdQwtZnSSyE58FQEXDAMnyeeq4vj7KgN75i5SlBzOs8A5MrtlD3gOlDKqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.140.0.tgz",
+      "integrity": "sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -7801,263 +7327,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@package-json/types": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@package-json/types/-/types-0.0.12.tgz",
-      "integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@parcel/watcher": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
-      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.3",
-        "is-glob": "^4.0.3",
-        "node-addon-api": "^7.0.0",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "@parcel/watcher-android-arm64": "2.5.6",
-        "@parcel/watcher-darwin-arm64": "2.5.6",
-        "@parcel/watcher-darwin-x64": "2.5.6",
-        "@parcel/watcher-freebsd-x64": "2.5.6",
-        "@parcel/watcher-linux-arm-glibc": "2.5.6",
-        "@parcel/watcher-linux-arm-musl": "2.5.6",
-        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
-        "@parcel/watcher-linux-arm64-musl": "2.5.6",
-        "@parcel/watcher-linux-x64-glibc": "2.5.6",
-        "@parcel/watcher-linux-x64-musl": "2.5.6",
-        "@parcel/watcher-win32-arm64": "2.5.6",
-        "@parcel/watcher-win32-ia32": "2.5.6",
-        "@parcel/watcher-win32-x64": "2.5.6"
-      }
-    },
-    "node_modules/@parcel/watcher-android-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
-      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-darwin-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
-      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-darwin-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
-      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-freebsd-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
-      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm-glibc": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
-      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm-musl": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
-      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm64-glibc": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
-      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm64-musl": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
-      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-glibc": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
-      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-musl": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
-      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/@parcel/watcher-wasm": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-wasm/-/watcher-wasm-2.5.6.tgz",
-      "integrity": "sha512-byAiBZ1t3tXQvc8dMD/eoyE7lTXYorhn+6uVW5AC+JGI1KtJC/LvDche5cfUE+qiefH+Ybq0bUCJU0aB1cSHUA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-wasm/-/watcher-wasm-2.6.0.tgz",
+      "integrity": "sha512-dtjbDxKSDPQ8AmA+pS4OFaHE1FKrjtGpLGBxw85uKFkRorjNbvDM/aFPgqosu40wprbp1xw2ZSxIKqghCUHe2w==",
       "bundleDependencies": [
         "napi-wasm"
       ],
@@ -8066,7 +7339,7 @@
       "dependencies": {
         "is-glob": "^4.0.3",
         "napi-wasm": "^1.1.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">= 10.0.0"
@@ -8081,69 +7354,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/@parcel/watcher-win32-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
-      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-ia32": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
-      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
-      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -8200,9 +7410,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.0.tgz",
+      "integrity": "sha512-9yB1l95IrJuNGDFdOYe79vdApdz6WWBCObE+rQ2LUliYUlcyFwSYIb2xb5/Ifw7dAtMy2ZqNyd8QTSOc7duAKw==",
       "cpu": [
         "arm64"
       ],
@@ -8212,15 +7422,14 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.0.tgz",
+      "integrity": "sha512-pexNaW9ACLUOaBITOpU6qVu4VrsOFIjTv6bzgu0YUATo4eUJx0V605PxwZfndpPOn0ilqGqvGQ0M8UW0IE24jg==",
       "cpu": [
         "arm64"
       ],
@@ -8230,15 +7439,14 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.0.tgz",
+      "integrity": "sha512-NqKYaq0355ZmNMG4QGpxtEDxsc7tGDhjhCm4PpE0cwnBW+5Il95LJyq414niEiaKLVjnVHBEjSo1wngKxJNiFw==",
       "cpu": [
         "x64"
       ],
@@ -8248,15 +7456,14 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.0.tgz",
+      "integrity": "sha512-3vPoHzh6eBTz9IbB0/qZdSr0Qeks2echn+I4cHu2joV74VriPDdldswksEDzrl1mBB+oPRi+67+3Ib59paxIPQ==",
       "cpu": [
         "x64"
       ],
@@ -8266,15 +7473,14 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.0.tgz",
+      "integrity": "sha512-E6NNefZ1bUVmKJq2tJkf45J4Zyczj7qm9rUT7NY+Xo2474Y13qWAwc2tvBt0BAVbmtXR1llkxXg0Ou1jbDf2SQ==",
       "cpu": [
         "arm"
       ],
@@ -8284,15 +7490,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.0.tgz",
+      "integrity": "sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w==",
       "cpu": [
         "arm64"
       ],
@@ -8302,15 +7507,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.0.tgz",
+      "integrity": "sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ==",
       "cpu": [
         "arm64"
       ],
@@ -8320,15 +7524,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.0.tgz",
+      "integrity": "sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw==",
       "cpu": [
         "ppc64"
       ],
@@ -8338,15 +7541,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.0.tgz",
+      "integrity": "sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ==",
       "cpu": [
         "s390x"
       ],
@@ -8356,15 +7558,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.0.tgz",
+      "integrity": "sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ==",
       "cpu": [
         "x64"
       ],
@@ -8374,15 +7575,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.0.tgz",
+      "integrity": "sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw==",
       "cpu": [
         "x64"
       ],
@@ -8392,15 +7592,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.0.tgz",
+      "integrity": "sha512-/6VFMQGRmrhP77KXDC+StIxGzcNp5JOIyYtw0CQ8gPlzhpiIRucYfoM5FaFamHd5BJYIdH86yfP46l1p3WdrFA==",
       "cpu": [
         "arm64"
       ],
@@ -8410,35 +7609,67 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.0.tgz",
+      "integrity": "sha512-rwdbUL465kisF24WEJLvP3JrEG6E5GRuIHt5wpMwHGERtHe4Wm2CIvtf5gTBgr2tGOHKh5NdKEAFS2VkOPE91g==",
       "cpu": [
         "wasm32"
       ],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
+        "@emnapi/core": "1.11.2",
+        "@emnapi/runtime": "1.11.2",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.0.tgz",
+      "integrity": "sha512-+5suHwRiKGmhwyUaNT8a5QbrBvLFh2DbO910TEmGRH1aSxwrCezodvGQnulv4uiWEIv1Kq4ypRsJ5+O+ry1DiA==",
       "cpu": [
         "arm64"
       ],
@@ -8448,15 +7679,14 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.0.tgz",
+      "integrity": "sha512-WfFv6/qGufotqBSBzBYwgpCkJBk8Nj7697LL9vTz/XWc67e0r3oewu8iMRwQj3AUL45GVD7wVsPjCsAAtW66Wg==",
       "cpu": [
         "x64"
       ],
@@ -8466,7 +7696,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -8711,9 +7940,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
-      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
       "cpu": [
         "arm"
       ],
@@ -8725,9 +7954,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
-      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
       "cpu": [
         "arm64"
       ],
@@ -8739,9 +7968,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
-      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
       "cpu": [
         "arm64"
       ],
@@ -8753,9 +7982,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
-      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
       "cpu": [
         "x64"
       ],
@@ -8767,9 +7996,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
-      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
       "cpu": [
         "arm64"
       ],
@@ -8781,9 +8010,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
-      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
       "cpu": [
         "x64"
       ],
@@ -8795,9 +8024,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
-      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
       ],
@@ -8809,9 +8038,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
-      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
       ],
@@ -8823,9 +8052,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
-      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
       "cpu": [
         "arm64"
       ],
@@ -8837,9 +8066,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
-      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
       ],
@@ -8851,9 +8080,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
-      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
       "cpu": [
         "loong64"
       ],
@@ -8865,9 +8094,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
-      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
       ],
@@ -8879,9 +8108,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
-      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
       "cpu": [
         "ppc64"
       ],
@@ -8893,9 +8122,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
-      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
       ],
@@ -8907,9 +8136,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
-      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
       "cpu": [
         "riscv64"
       ],
@@ -8921,9 +8150,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
-      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
       ],
@@ -8935,9 +8164,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
-      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
       "cpu": [
         "s390x"
       ],
@@ -8949,9 +8178,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
-      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "cpu": [
         "x64"
       ],
@@ -8963,9 +8192,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
-      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
       ],
@@ -8977,9 +8206,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
-      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
       "cpu": [
         "x64"
       ],
@@ -8991,9 +8220,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
-      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
       "cpu": [
         "arm64"
       ],
@@ -9005,9 +8234,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
-      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
       "cpu": [
         "arm64"
       ],
@@ -9019,9 +8248,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
-      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
       "cpu": [
         "ia32"
       ],
@@ -9033,9 +8262,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
-      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
       "cpu": [
         "x64"
       ],
@@ -9047,9 +8276,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
-      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
       "cpu": [
         "x64"
       ],
@@ -9124,9 +8353,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/@stripe/stripe-js": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.9.0.tgz",
-      "integrity": "sha512-Vwqe6Q5cU4i82tPyAv2BpaW/fQSNdOSO4/J8EeDLPp5/oIZiMmdB+Hgh863zFH+rtoxpuWGvD1L7QPh8k1Rdvw==",
+      "version": "9.10.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.10.0.tgz",
+      "integrity": "sha512-rxkKgWLAWtjvJhqEynPJ5zPXoKx5cK4eIUunnMGxwUJDRHKv3MlpA1mCCXdeiXzui5YZNWJKUJBTpe7m30jhOA==",
       "license": "MIT",
       "engines": {
         "node": ">=12.16"
@@ -9176,47 +8405,47 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
-      "integrity": "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "5.21.6",
+        "enhanced-resolve": "^5.24.1",
         "jiti": "^2.7.0",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.3.2"
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
-      "integrity": "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.3.2",
-        "@tailwindcss/oxide-darwin-arm64": "4.3.2",
-        "@tailwindcss/oxide-darwin-x64": "4.3.2",
-        "@tailwindcss/oxide-freebsd-x64": "4.3.2",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.2",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.3.2",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.3.2",
-        "@tailwindcss/oxide-linux-x64-musl": "4.3.2",
-        "@tailwindcss/oxide-wasm32-wasi": "4.3.2",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.2",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.3.2"
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.2.tgz",
-      "integrity": "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
       "cpu": [
         "arm64"
       ],
@@ -9230,9 +8459,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.2.tgz",
-      "integrity": "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
       "cpu": [
         "arm64"
       ],
@@ -9246,9 +8475,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.2.tgz",
-      "integrity": "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
       "cpu": [
         "x64"
       ],
@@ -9262,9 +8491,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.2.tgz",
-      "integrity": "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
       "cpu": [
         "x64"
       ],
@@ -9278,9 +8507,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.2.tgz",
-      "integrity": "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
       "cpu": [
         "arm"
       ],
@@ -9294,9 +8523,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.2.tgz",
-      "integrity": "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
       "cpu": [
         "arm64"
       ],
@@ -9310,9 +8539,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.2.tgz",
-      "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
       ],
@@ -9326,9 +8555,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.2.tgz",
-      "integrity": "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
       "cpu": [
         "x64"
       ],
@@ -9342,9 +8571,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.2.tgz",
-      "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
       ],
@@ -9358,9 +8587,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.2.tgz",
-      "integrity": "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -9387,9 +8616,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
-      "integrity": "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
       "cpu": [
         "arm64"
       ],
@@ -9403,9 +8632,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.2.tgz",
-      "integrity": "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
       "cpu": [
         "x64"
       ],
@@ -9419,16 +8648,16 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.2.tgz",
-      "integrity": "sha512-rjVWYCa7Ngbi5AarT6k8TkxUG3Wl1QKzHdIZVsjZSzf36Jmo2IKZt/NHRAwly8oDkbBOH0YTu+CHuf9jPxMc+g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.3.tgz",
+      "integrity": "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==",
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.3.2",
-        "@tailwindcss/oxide": "4.3.2",
-        "postcss": "^8.5.15",
-        "tailwindcss": "4.3.2"
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "postcss": "^8.5.16",
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/typography": {
@@ -9445,9 +8674,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.0.tgz",
-      "integrity": "sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ==",
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.5.tgz",
+      "integrity": "sha512-AXfBC3sq6PuYSwyxYORqqgHCNjPGAvKJvZuBBJ1klhztWBB5cgqgwsq8+fNfaQJG7/K4xYBja9S90QFn2zmQAg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -9455,12 +8684,12 @@
       }
     },
     "node_modules/@tanstack/vue-virtual": {
-      "version": "3.13.28",
-      "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.28.tgz",
-      "integrity": "sha512-A+jWpXtMpWXKhGLKQrXeC9mk1VgYeMWSJ+o0CTCEi+HLYMSQFdVmPG9lJz7d4XJyIkc5xVwZU9QY67QpScqnxA==",
+      "version": "3.13.33",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.33.tgz",
+      "integrity": "sha512-R1j/o/5pdgzDqV3Us/s7VEV1Il6ocTsElKxK9g04rq66V3m7kIULgKXD04BAQwCO0IMemXsw3ex6LSH4ug3Feg==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.17.0"
+        "@tanstack/virtual-core": "3.17.5"
       },
       "funding": {
         "type": "github",
@@ -9487,9 +8716,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9525,13 +8754,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -9565,17 +8794,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
-      "integrity": "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.61.0",
-        "@typescript-eslint/type-utils": "8.61.0",
-        "@typescript-eslint/utils": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -9588,22 +8817,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.61.0",
+        "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
-      "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.61.0",
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -9619,14 +8848,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
-      "integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.61.0",
-        "@typescript-eslint/types": "^8.61.0",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -9641,14 +8870,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
-      "integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -9659,9 +8888,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
-      "integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9676,15 +8905,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz",
-      "integrity": "sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0",
-        "@typescript-eslint/utils": "8.61.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -9701,9 +8930,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
-      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9715,16 +8944,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
-      "integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.61.0",
-        "@typescript-eslint/tsconfig-utils": "8.61.0",
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -9743,9 +8972,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -9756,16 +8985,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.0.tgz",
-      "integrity": "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.61.0",
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -9780,13 +9009,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
-      "integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/types": "8.65.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -9810,21 +9039,135 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@unhead/vue": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.15.tgz",
-      "integrity": "sha512-SSByXfEjhzPn8gXdEdgpYqpLMPSkLUH2HVE0GxZfOtNsJ0GgOHQs0g9T67ZZ1z0kTELLKdtOtYrzrbv9+ffF7g==",
+    "node_modules/@unhead/bundler": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@unhead/bundler/-/bundler-3.2.1.tgz",
+      "integrity": "sha512-lMJGiviHfmZT1dtL+VAi4AgP0NrT1dZXDVK96lajUF4tIYxha1FEo0yQun0lp1J+RL8BE2pm3u2LZY9564dA1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hookable": "^6.0.1",
-        "unhead": "2.1.15"
+        "@vitejs/devtools-kit": "^0.3.4",
+        "magic-string": "^1.0.0",
+        "oxc-parser": "^0.140.0",
+        "oxc-walker": "^1.0.0",
+        "ufo": "^1.6.4",
+        "unplugin": "^3.3.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/harlan-zw"
       },
       "peerDependencies": {
-        "vue": ">=3.5.18"
+        "@unhead/cli": "^3.2.1",
+        "esbuild": ">=0.17.0",
+        "lightningcss": ">=1.20.0",
+        "rolldown": ">=1.0.0-beta.0",
+        "unhead": "^3.2.1",
+        "vite": ">=6.4.2",
+        "webpack": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@unhead/cli": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@unhead/bundler/node_modules/magic-regexp": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/magic-regexp/-/magic-regexp-0.11.0.tgz",
+      "integrity": "sha512-LG77Z/gVnwz7oaDpD4heX6ryl+lcr4l1B2gnP4MMvt2pGhGC1Dfj7dl1pXpP4ih+VQFLuAadeKVa+lARAzfW+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.21",
+        "regexp-tree": "^0.1.27",
+        "type-level-regexp": "~0.1.17",
+        "unplugin": "^3.0.0"
+      }
+    },
+    "node_modules/@unhead/bundler/node_modules/magic-regexp/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@unhead/bundler/node_modules/magic-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.0.0.tgz",
+      "integrity": "sha512-CGvjzMN08iv6w1mm4/x3Gh1hLb4VnyRUA15FFpl6CsCIGGoe36k7kY5KNz9QDbSBN5I/fWHM6ZlIkUTa5xdUEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@unhead/bundler/node_modules/oxc-walker": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oxc-walker/-/oxc-walker-1.0.0.tgz",
+      "integrity": "sha512-eMsHflAGfOskpWxtp9xP/f5b96XLEU8ifTd2gOOCkdux9HMxKGy5S1ru0Gh1B3aPu+YbfmWUUVkcb7MrZz3XyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-regexp": "^0.11.0"
+      },
+      "peerDependencies": {
+        "oxc-parser": ">=0.98.0",
+        "rolldown": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "oxc-parser": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@unhead/vue": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-3.2.1.tgz",
+      "integrity": "sha512-HILBUv/3QDIze3SosuL0/fkXhBsw+XfDM8Et62O1R4sAAVcjxnggc8JSYn6LrgEKht1GABnz94usRtBe3SofgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@unhead/bundler": "3.2.1",
+        "hookable": "^6.1.1",
+        "unhead": "3.2.1",
+        "unplugin": "^3.3.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "vite": ">=6.4.2",
+        "vue": ">=3.5.18",
+        "webpack": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
@@ -10202,9 +9545,9 @@
       }
     },
     "node_modules/@vite-pwa/nuxt/node_modules/@nuxt/kit": {
-      "version": "3.21.8",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.8.tgz",
-      "integrity": "sha512-kg63DUPY5AHPn+9XM7u8rYcdWHXjzwfUscgRDuiC5YUciQ+xdLRhdwXelYFxEAx2nxJHossliiQXbMm/Fleivw==",
+      "version": "3.21.9",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.9.tgz",
+      "integrity": "sha512-SJ3W7INBJLwnmFQPm2BACiqS25enc6QIm87aLQCcxo/TFtRnWanYtgDdwyHqUHgOAGmq9pYjgk83B2bpBKnDTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10213,8 +9556,8 @@
         "defu": "^6.1.7",
         "destr": "^2.0.5",
         "errx": "^0.1.0",
-        "exsolve": "^1.0.8",
-        "ignore": "^7.0.5",
+        "exsolve": "^1.1.0",
+        "ignore": "^7.0.6",
         "jiti": "^2.7.0",
         "klona": "^2.0.6",
         "knitwork": "^1.3.0",
@@ -10224,8 +9567,8 @@
         "pkg-types": "^2.3.1",
         "rc9": "^3.0.1",
         "scule": "^1.3.0",
-        "semver": "^7.8.0",
-        "tinyglobby": "^0.2.16",
+        "semver": "^7.8.5",
+        "tinyglobby": "^0.2.17",
         "ufo": "^1.6.4",
         "unctx": "^2.5.0",
         "untyped": "^2.0.0"
@@ -10240,6 +9583,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vite-pwa/nuxt/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
     },
     "node_modules/@vite-pwa/nuxt/node_modules/pathe": {
       "version": "1.1.2",
@@ -10261,10 +9614,565 @@
         "node": ">=10"
       }
     },
+    "node_modules/@vite-pwa/nuxt/node_modules/unctx": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.5.0.tgz",
+      "integrity": "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21",
+        "unplugin": "^2.3.11"
+      }
+    },
+    "node_modules/@vite-pwa/nuxt/node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/devtools-kit/-/devtools-kit-0.3.4.tgz",
+      "integrity": "sha512-QHvb3wF0KZxvbfEplzzdGenB/dWoPBQlUnw3VVBm5qUYTdoud8rOoem9QI6h/+7a+iwy88LmLigxbSXbbv2Uyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@devframes/hub": "^0.5.4",
+        "birpc": "^4.0.0",
+        "devframe": "^0.5.4",
+        "mlly": "^1.8.2",
+        "nostics": "^1.1.4",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^2.1.0",
+        "tinyexec": "^1.2.4"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@devframes/hub": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@devframes/hub/-/hub-0.5.4.tgz",
+      "integrity": "sha512-NZs5RFuNb6tjQd2JBsRYQT+OqE+z16Kg9/72HG4k+uJdzK90sAGtAjOwK8bsvav/9l85KGx4agfkgxnfbl313w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "birpc": "^4.0.0",
+        "nostics": "^0.2.0",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^2.1.0",
+        "tinyexec": "^1.2.2"
+      },
+      "peerDependencies": {
+        "devframe": "0.5.4"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@devframes/hub/node_modules/nostics": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nostics/-/nostics-0.2.0.tgz",
+      "integrity": "sha512-/WQpI46UMbqvy1okYb+V+9wW3J8/m6GJ33wm691n/tyi6YtJiZ6ssJjENAU7y4evfYrrgYN9HllKDzPvffil1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.21",
+        "oxc-parser": "^0.132.0",
+        "unplugin": "^3.0.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.132.0.tgz",
+      "integrity": "sha512-KrLaPWa5c9Y7LkW+rKkaUE3y7DBDrQtaf7rlsSDfv6KAHUjgzAIRA761Lrrp6//Yd/Rlie/yEOt9YENCoJnOcw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.132.0.tgz",
+      "integrity": "sha512-SThDrSeamB/kG2+NxcJ5/wSLcV6dUqDknrPLqFYQ0ST/55mtBP4M7Q/f3QbubH6aAd11wpzZn/nwbVRSdobOpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.132.0.tgz",
+      "integrity": "sha512-Lc0f/TYoKBghE5/2Gsv7bLXk+TJZunx2Tf61X8hG4ARXdc8UYI26dCGccFSd1AyFbK3jfaNXtMnupggDbjPXdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.132.0.tgz",
+      "integrity": "sha512-RG2eJIpf7C21z9HSSXFw1bTArdpKe7Y4fwcJTwRq1yCSe1vSavaN9GA1sm9KqzemTLAGVktQ+7qBTGp0vQeUZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.132.0.tgz",
+      "integrity": "sha512-wQIPntPLtJ8NcBpvKPbEv3NqzV6k8eP8tP/jE9Rg8HTg/j7urZGFSsTCPCW5k77Qfw2DM4vRvc9p3I4yq/Shvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.132.0.tgz",
+      "integrity": "sha512-PixKEpeSe3yxQWqNyOCBALRYc72+Tj7ILDofUl3iXo25cVOzLA6jHUhmOINRtWIPh7dbUie3QNeabwaQpZTw6w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.132.0.tgz",
+      "integrity": "sha512-sCR+DzGHlyHKnbA2z9zWjTUhIo8Sy0enJl4RDsBwPmkxYynPatpwOAWe8W5127SlW0boqUWHGtr1NWn5UwIhXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.132.0.tgz",
+      "integrity": "sha512-sQBix5P2cW+IpzTcCwYxnh9yALrKSIkKJThspBvMGcygSMnbzkSvhN7SfuX1hvBk8y1XEChsdkU3ET0V5DmzUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.132.0.tgz",
+      "integrity": "sha512-WozHg3Kc//8Sk756HXXgMbEAvqtG+Lzb9JOojwQzIGDtN78Az2dLttkb71akWYUF/8IgYfDSlfKh4Uot8is5Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.132.0.tgz",
+      "integrity": "sha512-CmX/ulNBOEwWTyVRmcpYKAcAizW6+OjtLJgo7fXoL9OqQvjF4VER8tPomv44vwzfSCy1BHbsB0ZlZYzYJNj4cA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.132.0.tgz",
+      "integrity": "sha512-j9oQS+hM90SdhviNGWbPgT4+Rlq+ac++q/zjgwPD1mVHgxHzATvoRGtDx0sXGmFOQ9J9YkwAhYGb5MAHL6TAsA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.132.0.tgz",
+      "integrity": "sha512-bLz+Xi+Agnfmd7kWPEsSVwCn2k4EyIalZkNBcQ0OGIv9rqn8VgCPLNd03tM9mKX/5TdlvDXalz0q71BIrOPNqg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.132.0.tgz",
+      "integrity": "sha512-U6t2qbJU0ypTfyj9QV3W1Y6mITDTL8ai/OR6NUn85vyHthOvobKWgXzU4tu0EskSzlpuVFz1g0jFGulDIUKHxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.132.0.tgz",
+      "integrity": "sha512-WcEaSNHFk8yz5YFlQQAlhq6jOFmZBB/RKE7uzhyCIf+pF1Lmv9gUH4221mle2Gd9iHyWT3ySNph8yZgb1xYdWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.132.0.tgz",
+      "integrity": "sha512-iQrV4iJzQgRwK3BWRmQl1C3C6g3wYpXN2WLdQdyR+efoUnncdShZAVp9OgcojtlD3MDRbuOMGG3SjxF4fL4nlQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.132.0.tgz",
+      "integrity": "sha512-FWzmUGrZ6GUby4U7WIwcCtab6tdmlTO3xTRRKyb5kjIJVEiaUAT8animUG/nK8ZCA8gkRkPOTId4rl6uTqUmJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.132.0.tgz",
+      "integrity": "sha512-TlbMppxJI5CjWDes0QaP6G3aneVg1yikBu5QYI+DUShF9WDL66ccgKFNNGmi/Wybtszw6hxwAvv76T4DaPKnHw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.132.0.tgz",
+      "integrity": "sha512-RH/NbFjGKqdUAUi7Oh3LQPxUk2hsWFEEQ38HSnbRQT8QjBZFKqL1fMbmsB3N4jy/KPh9iX94+9dmkEMBBbambw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.132.0.tgz",
+      "integrity": "sha512-JUr4jQY9jxoIB/YTLXr6XofSi5xikj6p5/Ns1h0VOBDT0j1jKU+kMsv2xxv51RwnETcXpA1Yw/9oUAfcqfaqEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.132.0.tgz",
+      "integrity": "sha512-2dapgHpA5X8DSXF4AU36hJWYf6zP0tKjMXFRAZFBD62pkevW/uhFDXoFH9Y/3Fd2EtDrw5ByNnR1wVE9X9y0SQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/crossws": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.10.tgz",
+      "integrity": "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "srvx": ">=0.11.5"
+      },
+      "peerDependenciesMeta": {
+        "srvx": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/devframe": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/devframe/-/devframe-0.5.4.tgz",
+      "integrity": "sha512-dbHU/LuptR1aMXcizjHUeY3gu7qVaRQoFYqbbyyGuO6Y+avFA4uQtwinHtG1qa7lRel/7b8JrBDm0nbnxU3vqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@valibot/to-json-schema": "^1.7.0",
+        "birpc": "^4.0.0",
+        "cac": "^7.0.0",
+        "h3": "2.0.1-rc.22",
+        "mrmime": "^2.0.1",
+        "nostics": "^0.2.0",
+        "pathe": "^2.0.3",
+        "valibot": "^1.4.1",
+        "ws": "^8.21.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/devframe/node_modules/nostics": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nostics/-/nostics-0.2.0.tgz",
+      "integrity": "sha512-/WQpI46UMbqvy1okYb+V+9wW3J8/m6GJ33wm691n/tyi6YtJiZ6ssJjENAU7y4evfYrrgYN9HllKDzPvffil1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.21",
+        "oxc-parser": "^0.132.0",
+        "unplugin": "^3.0.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/h3": {
+      "version": "2.0.1-rc.22",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.22.tgz",
+      "integrity": "sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rou3": "^0.8.1",
+        "srvx": "^0.11.15"
+      },
+      "bin": {
+        "h3": "bin/h3.mjs"
+      },
+      "engines": {
+        "node": ">=20.11.1"
+      },
+      "peerDependencies": {
+        "crossws": "^0.4.1"
+      },
+      "peerDependenciesMeta": {
+        "crossws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/oxc-parser": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.132.0.tgz",
+      "integrity": "sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.132.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.132.0",
+        "@oxc-parser/binding-android-arm64": "0.132.0",
+        "@oxc-parser/binding-darwin-arm64": "0.132.0",
+        "@oxc-parser/binding-darwin-x64": "0.132.0",
+        "@oxc-parser/binding-freebsd-x64": "0.132.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.132.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.132.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.132.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.132.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.132.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.132.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.132.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.132.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.132.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.132.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/rou3": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.8.1.tgz",
+      "integrity": "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.7.tgz",
-      "integrity": "sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.8.tgz",
+      "integrity": "sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10279,16 +10187,16 @@
       }
     },
     "node_modules/@vitejs/plugin-vue-jsx": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue-jsx/-/plugin-vue-jsx-5.1.5.tgz",
-      "integrity": "sha512-jIAsvHOEtWpslLOI2MeElGFxH7M8pM83BU/Tor4RLyiwH0FM4nUW3xdvbw20EeU9wc5IspQwMq225K3CMnJEpA==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue-jsx/-/plugin-vue-jsx-5.1.6.tgz",
+      "integrity": "sha512-YXvi4as2clxt6DFw5+a0tTA97ntiQXm/raR8ofNj3aNwwdlVGTiG2gp7EvfZW17P50acL/9bP0ccF4XnqNmlgA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.29.0",
-        "@babel/plugin-syntax-typescript": "^7.28.6",
-        "@babel/plugin-transform-typescript": "^7.28.6",
-        "@rolldown/pluginutils": "^1.0.0-rc.2",
+        "@babel/plugin-syntax-typescript": "^7.29.7",
+        "@babel/plugin-transform-typescript": "^7.29.7",
+        "@rolldown/pluginutils": "^1.0.1",
         "@vue/babel-plugin-jsx": "^2.0.1"
       },
       "engines": {
@@ -10329,9 +10237,9 @@
       }
     },
     "node_modules/@vue-macros/common": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.1.2.tgz",
-      "integrity": "sha512-h9t4ArDdniO9ekYHAD95t9AZcAbb19lEGK+26iAjUODOIJKmObDNBSe4+6ELQAA3vtYiFPPBtHh7+cQCKi3Dng==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.1.4.tgz",
+      "integrity": "sha512-/5Fv+6DgIcM9ajY05ZmKBv+LMX1M9A0X+IUwDRVdt67ciw8OV9bvG2r34p3RiEadlsQybjhKPRKNXDC8Bp23cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10410,53 +10318,53 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.38.tgz",
-      "integrity": "sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.40.tgz",
+      "integrity": "sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.7",
-        "@vue/shared": "3.5.38",
+        "@vue/shared": "3.5.40",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.38.tgz",
-      "integrity": "sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.40.tgz",
+      "integrity": "sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.38",
-        "@vue/shared": "3.5.38"
+        "@vue/compiler-core": "3.5.40",
+        "@vue/shared": "3.5.40"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.38.tgz",
-      "integrity": "sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.40.tgz",
+      "integrity": "sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.7",
-        "@vue/compiler-core": "3.5.38",
-        "@vue/compiler-dom": "3.5.38",
-        "@vue/compiler-ssr": "3.5.38",
-        "@vue/shared": "3.5.38",
+        "@vue/compiler-core": "3.5.40",
+        "@vue/compiler-dom": "3.5.40",
+        "@vue/compiler-ssr": "3.5.40",
+        "@vue/shared": "3.5.40",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.15",
+        "postcss": "^8.5.19",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.38.tgz",
-      "integrity": "sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.40.tgz",
+      "integrity": "sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.38",
-        "@vue/shared": "3.5.38"
+        "@vue/compiler-dom": "3.5.40",
+        "@vue/shared": "3.5.40"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -10467,27 +10375,27 @@
       "license": "MIT"
     },
     "node_modules/@vue/devtools-core": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-8.1.3.tgz",
-      "integrity": "sha512-xezkv5/CPH/o5C8PE2Len9MnTJMsctYYQbKbbUiNOJpKd+fRHj27nKDb/sbtYI8NSQduegeQhCJGKRgAiOV6Uw==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-8.1.5.tgz",
+      "integrity": "sha512-5e5jQOEssCdZA1wlFEUkIDtb+cAOWuLNWJ52fm4PBWbF7e3oTnM2fneaL42E5lJoolAaUQ678tv/XEb3h4e86Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-kit": "^8.1.3",
-        "@vue/devtools-shared": "^8.1.3"
+        "@vue/devtools-kit": "^8.1.5",
+        "@vue/devtools-shared": "^8.1.5"
       },
       "peerDependencies": {
         "vue": "^3.0.0"
       }
     },
     "node_modules/@vue/devtools-kit": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.3.tgz",
-      "integrity": "sha512-cRn7GXiCQkMYU2Z3h3pM4YO/ndbx9FY1yLDAqIqPLcmIq4H6zAOJHein6tvZU3AfPwgrodqLiPBEF+YQaS8AxA==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.5.tgz",
+      "integrity": "sha512-FcSAxsi4eWuXLCB7Rv9lj0aIVHHPNVQ2BazGf4RJTc2JCqb4BQg0hk87ZFhminCfl+mD5OUI0rX2cgyu4kJOGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-shared": "^8.1.3",
+        "@vue/devtools-shared": "^8.1.5",
         "birpc": "^2.6.1",
         "hookable": "^5.5.3",
         "perfect-debounce": "^2.0.0"
@@ -10511,9 +10419,9 @@
       "license": "MIT"
     },
     "node_modules/@vue/devtools-shared": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.3.tgz",
-      "integrity": "sha512-CM3uIPL+v+lrJUk33+pxspYo0MhuMWlCvf7zC9fybifvCPyM2jUbYRPwoYEJgYbwRqPikm5HozbUhp60MF2QuA==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.5.tgz",
+      "integrity": "sha512-mhT4zcPFhF+Xk1O4BfhhrbXzpmfqY03fS6xGpcllbQG7lDjhQf8pQHcTIhqQIYx1hfwtHmk/6jM96ele0UxPqQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -10534,53 +10442,51 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.38.tgz",
-      "integrity": "sha512-pG6LV/NDNRbKizcUjFFLAfjaL8mcv4DmR9avNcUw2gDHBzZneuS2TWCmp633ynzxz9YYKNeEPK2I8Wraqy2HUQ==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.40.tgz",
+      "integrity": "sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.38"
+        "@vue/shared": "3.5.40"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.38.tgz",
-      "integrity": "sha512-iyW8WVfF1CpCXxncZY5Ei6rSd6oZr5DgEom//fUjRBRl56AXPD+s9ATvukRt77ZFTuYlnVA1bxY+dJB94tWVYw==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.40.tgz",
+      "integrity": "sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.38",
-        "@vue/shared": "3.5.38"
+        "@vue/reactivity": "3.5.40",
+        "@vue/shared": "3.5.40"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.38.tgz",
-      "integrity": "sha512-apX2wt9sdfDshS+a2xueFZLVpt0GkRJZSoPmrW/SA4yzXTznhfcMVW59gr7h4YQeY0vJhdJkk2rsIDwgfFgC5A==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.40.tgz",
+      "integrity": "sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.38",
-        "@vue/runtime-core": "3.5.38",
-        "@vue/shared": "3.5.38",
+        "@vue/reactivity": "3.5.40",
+        "@vue/runtime-core": "3.5.40",
+        "@vue/shared": "3.5.40",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.38.tgz",
-      "integrity": "sha512-vue8vbf2QlV4quHqzwmJy6dWfmRhP1J8l4wtZg60CL6VoKqcPY2oe7may3+1d9qfpedjK5PRLFqd5k3Isj9mUw==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.40.tgz",
+      "integrity": "sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.38",
-        "@vue/shared": "3.5.38"
-      },
-      "peerDependencies": {
-        "vue": "3.5.38"
+        "@vue/compiler-ssr": "3.5.40",
+        "@vue/runtime-dom": "3.5.40",
+        "@vue/shared": "3.5.40"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.38.tgz",
-      "integrity": "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.40.tgz",
+      "integrity": "sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==",
       "license": "MIT"
     },
     "node_modules/@vueuse/core": {
@@ -10893,9 +10799,9 @@
       "license": "MIT"
     },
     "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11138,9 +11044,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
-      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
+      "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
       "dev": true,
       "funding": [
         {
@@ -11158,8 +11064,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.2",
-        "caniuse-lite": "^1.0.30001787",
+        "browserslist": "^4.28.6",
+        "caniuse-lite": "^1.0.30001806",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -11273,9 +11179,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
-      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -11297,25 +11203,12 @@
         }
       }
     },
-    "node_modules/bare-os": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
-      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "bare": ">=1.14.0"
-      }
-    },
     "node_modules/bare-path": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
-      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
       "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-os": "^3.0.1"
-      }
+      "license": "Apache-2.0"
     },
     "node_modules/bare-stream": {
       "version": "2.13.3",
@@ -11377,9 +11270,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.37",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
-      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
+      "version": "2.10.44",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.44.tgz",
+      "integrity": "sha512-T3ghW+sl/ZJ8w1v/yQx3qvJ9040DWoLBz8JT/CILbAKcFyG9b2MRe75v6W5uXjv6uH1lumK2Kv46y2zSkcej0Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -11417,9 +11310,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11443,9 +11336,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
       "dev": true,
       "funding": [
         {
@@ -11463,10 +11356,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -11519,9 +11412,9 @@
       "license": "MIT"
     },
     "node_modules/builtin-modules": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.2.0.tgz",
-      "integrity": "sha512-02yxLeyxF4dNl6SlY6/5HfRSrSdZ/sCPoxy2kZNP5dZZX8LSAD9aE2gtJIUgWrsQTiMPl3mxESyrobSwvRGisQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.3.0.tgz",
+      "integrity": "sha512-hMQUl2bUFG339QygPM97E+mc8OY1IAchORZxm4a/frcYwKzozMzRVDBwHW0NjOqGElLm2O37AVQE8ikxlZHrMQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11669,9 +11562,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -11735,9 +11628,9 @@
       }
     },
     "node_modules/chardet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
       "dev": true,
       "license": "MIT"
     },
@@ -12668,28 +12561,30 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
-      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.2.tgz",
+      "integrity": "sha512-DObPPAfdtFbXjxLqK8s2Xk9ZuWz5+ZoFEhC7J76es4GU/rEiXwHTmbImoCdyoCOcBH1UF3+Cz6Z2sYD4hyl5TA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/devframe": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/devframe/-/devframe-0.5.4.tgz",
-      "integrity": "sha512-dbHU/LuptR1aMXcizjHUeY3gu7qVaRQoFYqbbyyGuO6Y+avFA4uQtwinHtG1qa7lRel/7b8JrBDm0nbnxU3vqg==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/devframe/-/devframe-0.6.2.tgz",
+      "integrity": "sha512-/P2MPHZzCRyuzEqPOThTDbiCsvbT7OkL1lj9/p6yiUycmC5xfRx5lOhjURYggSyTzEpOSUuWtlicr53ohEFZ5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@valibot/to-json-schema": "^1.7.0",
+        "@valibot/to-json-schema": "^1.7.1",
         "birpc": "^4.0.0",
         "cac": "^7.0.0",
+        "crossws": "^0.4.9",
+        "destr": "^2.0.5",
         "h3": "2.0.1-rc.22",
         "mrmime": "^2.0.1",
-        "nostics": "^0.2.0",
+        "nostics": "^1.1.4",
         "pathe": "^2.0.3",
-        "valibot": "^1.4.1",
-        "ws": "^8.21.0"
+        "ufo": "^1.6.4",
+        "valibot": "^1.4.2"
       },
       "peerDependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"
@@ -12701,13 +12596,11 @@
       }
     },
     "node_modules/devframe/node_modules/crossws": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.6.tgz",
-      "integrity": "sha512-/Wxe9Z007EbJ496j88nToZEvyPZ8PY/wjZJ18Agh/GCA9cYHyLbxtrpdFlFzAw3TV20F0SUYGl0g6PzChbwUrg==",
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.10.tgz",
+      "integrity": "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "peerDependencies": {
         "srvx": ">=0.11.5"
       },
@@ -12741,6 +12634,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/devframe/node_modules/rou3": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.8.1.tgz",
+      "integrity": "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/diff": {
       "version": "8.0.4",
@@ -12930,9 +12830,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.372",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
-      "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
+      "version": "1.5.393",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
       "dev": true,
       "license": "ISC"
     },
@@ -12954,9 +12854,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.6",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
-      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "version": "5.24.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
+      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -13137,9 +13037,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
     },
@@ -13441,13 +13341,12 @@
       }
     },
     "node_modules/eslint-plugin-import-x": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.2.tgz",
-      "integrity": "sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.17.1.tgz",
+      "integrity": "sha512-4cdstYkKCyjumM2Q9NSI03K8D2a9F4Ssz33K2lv2hQa4KmR9jPLwk3uWGtNvclfqBrPGfGuMBwsGMbe6dMRbfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@package-json/types": "^0.0.12",
         "@typescript-eslint/types": "^8.56.0",
         "comment-parser": "^1.4.1",
         "debug": "^4.4.1",
@@ -13479,9 +13378,9 @@
       }
     },
     "node_modules/eslint-plugin-import-x/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -13492,13 +13391,13 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "63.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.0.2.tgz",
-      "integrity": "sha512-0TchoK1uS4VxHSo3P4CyWQ31Lm+6zsT+xkHMC5KbFKwgOf8YrXPf1Bl8EP7kpgw1wfe/Ui5jz5mSX7ou8WAVuw==",
+      "version": "63.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.2.0.tgz",
+      "integrity": "sha512-tccz9igEV5mTKVAwo/KwXqKP7ENqa3a+LpRFuEPAP3k/+SXG4T0sOvA+c2wwTD/TLNrH9MCW4LIu4xEExkJdzg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.87.0",
+        "@es-joy/jsdoccomment": "~0.88.0",
         "@es-joy/resolve.exports": "1.2.0",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.4.7",
@@ -13509,7 +13408,7 @@
         "html-entities": "^2.6.0",
         "object-deep-merge": "^2.0.1",
         "parse-imports-exports": "^0.2.4",
-        "semver": "^7.8.2",
+        "semver": "^7.8.5",
         "spdx-expression-parse": "^4.0.0",
         "to-valid-identifier": "^1.0.0"
       },
@@ -13552,9 +13451,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -13565,9 +13464,9 @@
       }
     },
     "node_modules/eslint-plugin-regexp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-3.1.0.tgz",
-      "integrity": "sha512-qGXIC3DIKZHcK1H9A9+Byz9gmndY6TTSRkSMTZpNXdyCw2ObSehRgccJv35n9AdUakEjQp5VFNLas6BMXizCZg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-3.1.1.tgz",
+      "integrity": "sha512-MxR5nqoQCtVWmJwia0D2+NlXX1xzdpkslsVOZLEYQ4PQWEaL65PCZXURxaBc3lPnkNFpNxzMIRmYVxdl8giXRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13620,9 +13519,9 @@
       }
     },
     "node_modules/eslint-plugin-unicorn/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -13633,18 +13532,18 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.9.2.tgz",
-      "integrity": "sha512-4g7ZP3pYcuqd7Zp0pzUKcos0W+RkjBz4EGdhJ92FcYk6v03Ti/GK5NwjgsjxHK+98eXDbHeK7VtX1az7/8doZA==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.10.0.tgz",
+      "integrity": "sha512-dL9x9rBHqqNcByWiLOHK6L0SB97V82/NC0cZRn9cXPjM7pCuWlpQQP9bFH4vjBv80ej1ZpzAkuD8zWH1o9bZbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
+        "@eslint-community/eslint-utils": "^4.9.1",
         "natural-compare": "^1.4.0",
         "nth-check": "^2.1.1",
-        "postcss-selector-parser": "^7.1.0",
-        "semver": "^7.6.3",
-        "xml-name-validator": "^4.0.0"
+        "postcss-selector-parser": "^7.1.4",
+        "semver": "^7.8.5",
+        "xml-name-validator": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -13679,9 +13578,9 @@
       }
     },
     "node_modules/eslint-plugin-vue/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -14026,9 +13925,9 @@
       }
     },
     "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
       "dev": true,
       "license": "MIT"
     },
@@ -14121,9 +14020,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -14237,9 +14136,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14322,6 +14221,13 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fnv1a-64": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fnv1a-64/-/fnv1a-64-0.1.1.tgz",
+      "integrity": "sha512-qMpkqWyaiNxwYG7Dt40Bxtp2wV6KW/1woXVJOEvR1KA2ffsZf8pyvlNwJgFHha3teh8iC3d4arvrJ0qTcU445A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -14469,9 +14375,9 @@
       }
     },
     "node_modules/fuse.js": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.4.2.tgz",
-      "integrity": "sha512-LVbzjD4WA6UP5B1UnP8wuaXJiLnqMdM/E4fiJXTJ5haJ5b/MBNsK29h2fm6swEoQaVQjvYFWKLE2RanyZIoRVQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.5.0.tgz",
+      "integrity": "sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -14687,9 +14593,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14847,9 +14753,9 @@
       }
     },
     "node_modules/graphql-tag": {
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
-      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "version": "2.12.7",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.7.tgz",
+      "integrity": "sha512-xnE/NFzy+0eIesvAsREJZ284zTl/wYuBAvpsFSDhRGRdRHdnE90M21Q3xAWyYInb0J756c6x0pIQ62+vtvOs1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14859,13 +14765,13 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/graphql-ws": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.8.tgz",
-      "integrity": "sha512-m3EOaNsUBXwAnkBWbzPfe0Nq8pXUfxsWnolC54sru3FzHvhTZL0Ouf/BoQsaGAXqM+YPerXOJ47BUnmgmoupCw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.1.0.tgz",
+      "integrity": "sha512-7ft6KWkuaLnLABwzEIimjUMeF0iByo2ThD6q0MICgsvp6nDuT5ppubKzEHniu8Kmlp5GNsLgr5dil8JMrIwUEQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14874,7 +14780,7 @@
       "peerDependencies": {
         "@fastify/websocket": "^10 || ^11",
         "crossws": "~0.3",
-        "graphql": "^15.10.1 || ^16",
+        "graphql": "^15.10.1 || ^16 || ^17",
         "ws": "^8"
       },
       "peerDependenciesMeta": {
@@ -15089,9 +14995,9 @@
       }
     },
     "node_modules/httpxy": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.3.tgz",
-      "integrity": "sha512-SMS9V6Sn7VWaS11lYhoAr0ceoaiolTWf4jYdJn0NJhCdKMu9R2H9Fh0LBDWBHQF6HRLI1PmaePYsjanSpE5PEw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.5.tgz",
+      "integrity": "sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==",
       "dev": true,
       "license": "MIT"
     },
@@ -15106,9 +15012,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15151,9 +15057,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15168,9 +15074,9 @@
       "license": "MIT"
     },
     "node_modules/immutable": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
-      "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "dev": true,
       "license": "MIT"
     },
@@ -16041,9 +15947,9 @@
       }
     },
     "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
@@ -16131,9 +16037,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -16280,9 +16186,9 @@
       }
     },
     "node_modules/jsonc-eslint-parser/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -16375,6 +16281,13 @@
       "engines": {
         "node": ">= 0.6.3"
       }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lazystream/node_modules/readable-stream": {
       "version": "2.3.8",
@@ -16703,34 +16616,40 @@
       "license": "MIT"
     },
     "node_modules/listhen": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/listhen/-/listhen-1.10.0.tgz",
-      "integrity": "sha512-kfz4C0OrC6IpaVMtYDJtf6PFjurxe9NBBoDAh/o2p587INryFOO4DQ9OetbCdDrWFt1m1CJKvYrzkGsuPHw8nQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/listhen/-/listhen-1.10.1.tgz",
+      "integrity": "sha512-6nt/86SkqUQSLW1ofz8MxC6RhRMqOl3ONISe6qqvJ3xj09aJWQx6DhgSZpugs3PX4PXdOas/WD6A9jx6J2N19A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/watcher": "^2.5.6",
         "@parcel/watcher-wasm": "^2.5.6",
         "citty": "^0.2.2",
         "consola": "^3.4.2",
-        "crossws": ">=0.2.0 <0.5.0",
+        "crossws": "^0.4.10",
         "defu": "^6.1.7",
         "get-port-please": "^3.2.0",
         "h3": "^1.15.11",
         "http-shutdown": "^1.2.2",
-        "jiti": "^2.6.1",
-        "mlly": "^1.8.2",
+        "jiti": "^2.7.0",
         "node-forge": "^1.4.0",
         "pathe": "^2.0.3",
-        "std-env": "^4.1.0",
-        "tinyclip": "^0.1.12",
+        "std-env": "^4.2.0",
+        "tinyclip": "^0.1.15",
         "ufo": "^1.6.4",
-        "untun": "^0.1.3",
+        "untun": "^0.2.2",
         "uqr": "^0.1.3"
       },
       "bin": {
         "listen": "bin/listhen.mjs",
         "listhen": "bin/listhen.mjs"
+      },
+      "peerDependencies": {
+        "@parcel/watcher": "^2.5.6"
+      },
+      "peerDependenciesMeta": {
+        "@parcel/watcher": {
+          "optional": true
+        }
       }
     },
     "node_modules/listhen/node_modules/citty": {
@@ -16740,10 +16659,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/listhen/node_modules/crossws": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.10.tgz",
+      "integrity": "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "srvx": ">=0.11.5"
+      },
+      "peerDependenciesMeta": {
+        "srvx": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/listr2": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
-      "integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.2.tgz",
+      "integrity": "sha512-JtNtbZj8q5BnDMR7trpwvwk3RIrANtIVzEUm8w7amp6xelLgyuq+4WZoTH913XaQAoH/cNdYhaNzBPA2U3xbDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17302,9 +17236,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -17470,10 +17404,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/nitropack/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/nitropack/node_modules/globby": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
-      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.2.tgz",
+      "integrity": "sha512-NLvV9ubZ6NDsJaOpKPy3cQeJpKi9DcWiyCiFUpJPA0YihRqiE6RWaLUmgNNPr8MgPpLZjnBjSmou7uZBRJv9wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17499,9 +17443,9 @@
       "license": "MIT"
     },
     "node_modules/nitropack/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -17534,6 +17478,19 @@
         "node": ">= 12"
       }
     },
+    "node_modules/nitropack/node_modules/unctx": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.5.0.tgz",
+      "integrity": "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21",
+        "unplugin": "^2.3.11"
+      }
+    },
     "node_modules/nitropack/node_modules/unicorn-magic": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
@@ -17547,6 +17504,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/nitropack/node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
     "node_modules/no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -17557,13 +17530,6 @@
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
       }
-    },
-    "node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -17644,9 +17610,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17680,406 +17646,11 @@
       }
     },
     "node_modules/nostics": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/nostics/-/nostics-0.2.0.tgz",
-      "integrity": "sha512-/WQpI46UMbqvy1okYb+V+9wW3J8/m6GJ33wm691n/tyi6YtJiZ6ssJjENAU7y4evfYrrgYN9HllKDzPvffil1w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nostics/-/nostics-1.2.0.tgz",
+      "integrity": "sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "magic-string": "^0.30.21",
-        "oxc-parser": "^0.132.0",
-        "unplugin": "^3.0.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-android-arm-eabi": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.132.0.tgz",
-      "integrity": "sha512-KrLaPWa5c9Y7LkW+rKkaUE3y7DBDrQtaf7rlsSDfv6KAHUjgzAIRA761Lrrp6//Yd/Rlie/yEOt9YENCoJnOcw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-android-arm64": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.132.0.tgz",
-      "integrity": "sha512-SThDrSeamB/kG2+NxcJ5/wSLcV6dUqDknrPLqFYQ0ST/55mtBP4M7Q/f3QbubH6aAd11wpzZn/nwbVRSdobOpg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-darwin-arm64": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.132.0.tgz",
-      "integrity": "sha512-Lc0f/TYoKBghE5/2Gsv7bLXk+TJZunx2Tf61X8hG4ARXdc8UYI26dCGccFSd1AyFbK3jfaNXtMnupggDbjPXdQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-darwin-x64": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.132.0.tgz",
-      "integrity": "sha512-RG2eJIpf7C21z9HSSXFw1bTArdpKe7Y4fwcJTwRq1yCSe1vSavaN9GA1sm9KqzemTLAGVktQ+7qBTGp0vQeUZg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-freebsd-x64": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.132.0.tgz",
-      "integrity": "sha512-wQIPntPLtJ8NcBpvKPbEv3NqzV6k8eP8tP/jE9Rg8HTg/j7urZGFSsTCPCW5k77Qfw2DM4vRvc9p3I4yq/Shvw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.132.0.tgz",
-      "integrity": "sha512-PixKEpeSe3yxQWqNyOCBALRYc72+Tj7ILDofUl3iXo25cVOzLA6jHUhmOINRtWIPh7dbUie3QNeabwaQpZTw6w==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.132.0.tgz",
-      "integrity": "sha512-sCR+DzGHlyHKnbA2z9zWjTUhIo8Sy0enJl4RDsBwPmkxYynPatpwOAWe8W5127SlW0boqUWHGtr1NWn5UwIhXQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.132.0.tgz",
-      "integrity": "sha512-sQBix5P2cW+IpzTcCwYxnh9yALrKSIkKJThspBvMGcygSMnbzkSvhN7SfuX1hvBk8y1XEChsdkU3ET0V5DmzUw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-linux-arm64-musl": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.132.0.tgz",
-      "integrity": "sha512-WozHg3Kc//8Sk756HXXgMbEAvqtG+Lzb9JOojwQzIGDtN78Az2dLttkb71akWYUF/8IgYfDSlfKh4Uot8is5Vw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.132.0.tgz",
-      "integrity": "sha512-CmX/ulNBOEwWTyVRmcpYKAcAizW6+OjtLJgo7fXoL9OqQvjF4VER8tPomv44vwzfSCy1BHbsB0ZlZYzYJNj4cA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.132.0.tgz",
-      "integrity": "sha512-j9oQS+hM90SdhviNGWbPgT4+Rlq+ac++q/zjgwPD1mVHgxHzATvoRGtDx0sXGmFOQ9J9YkwAhYGb5MAHL6TAsA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.132.0.tgz",
-      "integrity": "sha512-bLz+Xi+Agnfmd7kWPEsSVwCn2k4EyIalZkNBcQ0OGIv9rqn8VgCPLNd03tM9mKX/5TdlvDXalz0q71BIrOPNqg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.132.0.tgz",
-      "integrity": "sha512-U6t2qbJU0ypTfyj9QV3W1Y6mITDTL8ai/OR6NUn85vyHthOvobKWgXzU4tu0EskSzlpuVFz1g0jFGulDIUKHxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-linux-x64-gnu": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.132.0.tgz",
-      "integrity": "sha512-WcEaSNHFk8yz5YFlQQAlhq6jOFmZBB/RKE7uzhyCIf+pF1Lmv9gUH4221mle2Gd9iHyWT3ySNph8yZgb1xYdWg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-linux-x64-musl": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.132.0.tgz",
-      "integrity": "sha512-iQrV4iJzQgRwK3BWRmQl1C3C6g3wYpXN2WLdQdyR+efoUnncdShZAVp9OgcojtlD3MDRbuOMGG3SjxF4fL4nlQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-openharmony-arm64": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.132.0.tgz",
-      "integrity": "sha512-FWzmUGrZ6GUby4U7WIwcCtab6tdmlTO3xTRRKyb5kjIJVEiaUAT8animUG/nK8ZCA8gkRkPOTId4rl6uTqUmJQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-wasm32-wasi": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.132.0.tgz",
-      "integrity": "sha512-TlbMppxJI5CjWDes0QaP6G3aneVg1yikBu5QYI+DUShF9WDL66ccgKFNNGmi/Wybtszw6hxwAvv76T4DaPKnHw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.132.0.tgz",
-      "integrity": "sha512-RH/NbFjGKqdUAUi7Oh3LQPxUk2hsWFEEQ38HSnbRQT8QjBZFKqL1fMbmsB3N4jy/KPh9iX94+9dmkEMBBbambw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.132.0.tgz",
-      "integrity": "sha512-JUr4jQY9jxoIB/YTLXr6XofSi5xikj6p5/Ns1h0VOBDT0j1jKU+kMsv2xxv51RwnETcXpA1Yw/9oUAfcqfaqEA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-parser/binding-win32-x64-msvc": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.132.0.tgz",
-      "integrity": "sha512-2dapgHpA5X8DSXF4AU36hJWYf6zP0tKjMXFRAZFBD62pkevW/uhFDXoFH9Y/3Fd2EtDrw5ByNnR1wVE9X9y0SQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nostics/node_modules/@oxc-project/types": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
-      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/nostics/node_modules/oxc-parser": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.132.0.tgz",
-      "integrity": "sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oxc-project/types": "^0.132.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      },
-      "optionalDependencies": {
-        "@oxc-parser/binding-android-arm-eabi": "0.132.0",
-        "@oxc-parser/binding-android-arm64": "0.132.0",
-        "@oxc-parser/binding-darwin-arm64": "0.132.0",
-        "@oxc-parser/binding-darwin-x64": "0.132.0",
-        "@oxc-parser/binding-freebsd-x64": "0.132.0",
-        "@oxc-parser/binding-linux-arm-gnueabihf": "0.132.0",
-        "@oxc-parser/binding-linux-arm-musleabihf": "0.132.0",
-        "@oxc-parser/binding-linux-arm64-gnu": "0.132.0",
-        "@oxc-parser/binding-linux-arm64-musl": "0.132.0",
-        "@oxc-parser/binding-linux-ppc64-gnu": "0.132.0",
-        "@oxc-parser/binding-linux-riscv64-gnu": "0.132.0",
-        "@oxc-parser/binding-linux-riscv64-musl": "0.132.0",
-        "@oxc-parser/binding-linux-s390x-gnu": "0.132.0",
-        "@oxc-parser/binding-linux-x64-gnu": "0.132.0",
-        "@oxc-parser/binding-linux-x64-musl": "0.132.0",
-        "@oxc-parser/binding-openharmony-arm64": "0.132.0",
-        "@oxc-parser/binding-wasm32-wasi": "0.132.0",
-        "@oxc-parser/binding-win32-arm64-msvc": "0.132.0",
-        "@oxc-parser/binding-win32-ia32-msvc": "0.132.0",
-        "@oxc-parser/binding-win32-x64-msvc": "0.132.0"
-      }
+      "license": "MIT"
     },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
@@ -18124,22 +17695,22 @@
       }
     },
     "node_modules/nuxt": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-4.4.8.tgz",
-      "integrity": "sha512-r/DGE4cNkEDclOw9tbJ18zqu+ix3me+7QCfumPdl5lBXGWgCajskzuq/HzDkHKfIZsn7ACVEjMLRNA2teh++bQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-4.5.0.tgz",
+      "integrity": "sha512-MbMAQFR9q8sDf80mp0v1sLtPuFDviSw7ntcBHPP0ok9phpirRy19NM9aDNRI6/12hU646BurrE0zCFJK0pq7NA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@dxup/nuxt": "^0.4.1",
-        "@nuxt/cli": "^3.35.2",
+        "@dxup/nuxt": "^0.5.3",
+        "@nuxt/cli": "^3.37.0",
         "@nuxt/devtools": "^3.2.4",
-        "@nuxt/kit": "4.4.8",
-        "@nuxt/nitro-server": "4.4.8",
-        "@nuxt/schema": "4.4.8",
+        "@nuxt/kit": "4.5.0",
+        "@nuxt/nitro-server": "4.5.0",
+        "@nuxt/schema": "4.5.0",
         "@nuxt/telemetry": "^2.8.0",
-        "@nuxt/vite-builder": "4.4.8",
-        "@unhead/vue": "^2.1.15",
-        "@vue/shared": "^3.5.35",
+        "@nuxt/vite-builder": "4.5.0",
+        "@unhead/vue": "^3.1.8",
+        "@vue/shared": "^3.5.39",
         "chokidar": "^5.0.0",
         "compatx": "^0.2.0",
         "consola": "^3.4.2",
@@ -18148,51 +17719,54 @@
         "devalue": "^5.8.1",
         "errx": "^0.1.0",
         "escape-string-regexp": "^5.0.0",
-        "exsolve": "^1.0.8",
+        "exsolve": "^1.1.0",
+        "fnv1a-64": "^0.1.1",
         "hookable": "^6.1.1",
-        "ignore": "^7.0.5",
+        "ignore": "^7.0.6",
         "impound": "^1.1.5",
         "jiti": "^2.7.0",
         "klona": "^2.0.6",
         "knitwork": "^1.3.0",
-        "magic-string": "^0.30.21",
+        "magic-string": "^1.0.0",
         "mlly": "^1.8.2",
         "nanotar": "^0.3.0",
-        "nypm": "^0.6.6",
+        "nostics": "^1.1.4",
+        "nypm": "^0.6.8",
+        "object-identity": "^0.2.3",
         "ofetch": "^1.5.1",
         "ohash": "^2.0.11",
         "on-change": "^6.0.2",
-        "oxc-minify": "^0.133.0",
-        "oxc-parser": "^0.133.0",
-        "oxc-transform": "^0.133.0",
         "oxc-walker": "^1.0.0",
         "pathe": "^2.0.3",
         "perfect-debounce": "^2.1.0",
-        "picomatch": "^4.0.4",
+        "picomatch": "^4.0.5",
         "pkg-types": "^2.3.1",
-        "rou3": "^0.8.1",
+        "rolldown": "^1.2.0",
+        "rolldown-string": "^0.3.0",
+        "rou3": "^0.9.1",
         "scule": "^1.3.0",
-        "semver": "^7.8.1",
-        "std-env": "^4.1.0",
+        "semver": "^7.8.5",
+        "std-env": "^4.2.0",
         "tinyglobby": "^0.2.17",
         "ufo": "^1.6.4",
-        "ultrahtml": "^1.6.0",
+        "ultrahtml": "^1.7.0",
         "uncrypto": "^0.1.3",
-        "unctx": "^2.5.0",
-        "unhead": "^2.1.15",
+        "unctx": "^3.0.0",
+        "undici": "^8.7.0",
+        "unhead": "^3.1.8",
         "unimport": "^6.3.0",
-        "unplugin": "^3.0.0",
+        "unplugin": "^3.3.0",
         "unrouting": "^0.1.7",
         "untyped": "^2.0.0",
-        "vue": "^3.5.35",
-        "vue-router": "^5.1.0"
+        "vue": "^3.5.39",
+        "vue-router": "^5.2.0"
       },
       "bin": {
         "nuxi": "bin/nuxt.mjs",
         "nuxt": "bin/nuxt.mjs"
       },
       "engines": {
-        "node": "^22.12.0 || ^24.11.0 || >=26.0.0"
+        "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
       },
       "peerDependencies": {
         "@parcel/watcher": "^2.1.0",
@@ -18215,700 +17789,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/bobbiegoede"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-android-arm-eabi": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.133.0.tgz",
-      "integrity": "sha512-l/44caGse+VpnY9gx0yvvc5QnnG3yG1FO3KZgYvNL1GZrfK86zIwAOgGEVlxDyRymzrU/KHiblPFpevKOmJmUA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-android-arm64": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.133.0.tgz",
-      "integrity": "sha512-KUHmPMziLBp4u+zbrLdB7iWS7KshuZe+RAp7ELnY9SI9nNXBZ+dp8fiBqWOxhXqn+FQg3a4UcQhwmsJOKV8Jjg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-darwin-arm64": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.133.0.tgz",
-      "integrity": "sha512-q8dWmnU/8ea2tga9w2f1PinQ5rcMPDUGkF64T189b65YMjUomET4oy5oRldOr4AwOQkneOG/Zttnz1Dvrc62wg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-darwin-x64": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.133.0.tgz",
-      "integrity": "sha512-cOKeIELIB2bJnCKwqx4Rdj+1Lss/U6uCbLxRySZrhyOOQa1flKhwZFjEHRHxk8fU1NKmhK5OnTdPQ4CpjuFuVw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-freebsd-x64": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.133.0.tgz",
-      "integrity": "sha512-OpaSv4pW3KgFrMYQxTaS0aOE4T1DQF3qZE/4B6uqqv1KgPWWd4UQhJALi8PJPX1RRV5K7ThKXRfF7qGg2+3l1A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.133.0.tgz",
-      "integrity": "sha512-JGK1wlGrGwxBIlVSF7KWTX1/ru6BEtf28fRROztDRkLfiW+Kxa4onnriezMIiogfn9hVw2KzYcKiLjkLR2ns8A==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.133.0.tgz",
-      "integrity": "sha512-yuZO533Ftonxn/iyoqQzURzLQHMspvsIyfiCSNi1t/ER4eIQaR0SsmUOUm5b/lmSig7IWIUa5/BrbEkAPwcilQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.133.0.tgz",
-      "integrity": "sha512-hvpbqT5pN2rR+3+xtWeizwfR/aZ0vGceg6TqYMl+ToxMpk9/tmnX7kSvQnfEUkoua8mhogzvIKsAkn0wxgblBA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-linux-arm64-musl": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.133.0.tgz",
-      "integrity": "sha512-wJQGamIosQBoJHW9+S5XxrtKRo3eyJxsnS1XCPrqN0LHi8uw1pTqqTfn3t/NVuvbBg7Pumn4ez9Eidgcn0xbEg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.133.0.tgz",
-      "integrity": "sha512-Koaz32/O5+abIfrNGdyndgRvdOZ9jEf5/z3Ep9h3h2QWpdDiUQpVwgH0OcMXCs+l9aXxPLtkupqyVig9W6FDKw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.133.0.tgz",
-      "integrity": "sha512-R4vOjWzxhnNWHnVLeiB6jNuIifdy9vcMXZGPc7StXcxBovI+U2zg1QhZ9o8OjV80oGivs1lX5NfPLzk4IPqlRA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.133.0.tgz",
-      "integrity": "sha512-iwgBNUTHiMdxARLYuM0SBlnYeb19iw1Ea5M+4ERZupCsBMLArti6FyZ6UfFjJxIiTDr2oW2DGQFxlQVQ/dW9rA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.133.0.tgz",
-      "integrity": "sha512-ZwZNo8FZmB/gVfboQl+wXilBigGl+6nQQs+nITOeAP/HcAOjiHl6XZJL9F/KXNEspODQcbjAiyjUbeCJd9a0fA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-linux-x64-gnu": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.133.0.tgz",
-      "integrity": "sha512-govCvWx1dBlED3uu4qXctxpRcouu9I8Kn+DBktGCl760JtlGJzc9l/OmPJKlYWSbrRqKkMZehNeZ/4Wfma7uSA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-linux-x64-musl": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.133.0.tgz",
-      "integrity": "sha512-ssTlpXD5Mq9uCssDJPzlRWqBt4Y7Zzd9i+XZhWmK/9Y6KUIuAxVYTYiI8lxcGWi0+3/Cz4A8q9UrD4NK9Y2j7g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-openharmony-arm64": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.133.0.tgz",
-      "integrity": "sha512-51aByfXhPtLEdWG4a2Ihdw6cPWV1ei1AarALpFdDP8MLWDLE2NuUMgbo3DERR2Kt8fT/ok1GUvBiLxVGke9uUQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-wasm32-wasi": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.133.0.tgz",
-      "integrity": "sha512-2e16tkKp+wDO2GTAmXfxbBcCmGEaFPIJEIRBBmVKNVXSc8/fJsSIaBGyFTPHM9ST5GNWgJcYIt94rDTks+PLwA==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.133.0.tgz",
-      "integrity": "sha512-KPTNDKbxH1cglrqTyVeXHb4Pk4oksz8EcE1/v8zqU7N4UXbiHfA/IwtXZ2U77fnRAWBbgVkl/lZbL7o3hRdejg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.133.0.tgz",
-      "integrity": "sha512-Una1bNYv9zCavQrfnDR9wuZVB3itLjCEH4Oz7i6CwAJN/Xq9b+zbbcxmvdkKvvJt4Ngc/MBmIYlbLo3zS4TQ0A==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-parser/binding-win32-x64-msvc": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.133.0.tgz",
-      "integrity": "sha512-kjBhCiOGSYTwDJQuuZa7a94JbP8htWu7J0X1KwH74kV2K5eYf6eyJRYmkpCDvr0XEL8tMxYI4WU1VekblFCLgg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-project/types": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-android-arm-eabi": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm-eabi/-/binding-android-arm-eabi-0.133.0.tgz",
-      "integrity": "sha512-2A79NBpyBKgHJ0FwgC8D1hzp3x2ujyvqq/kG+M76YyDMMkxLhX6A3vjnAnfEKycOoZxuKhwYu8BF9hKq67ykIA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-android-arm64": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm64/-/binding-android-arm64-0.133.0.tgz",
-      "integrity": "sha512-dynEph/hyoSgBzd2XbNlW37NK97nU6tZMs5jrhObUxSasBV/Gv9THZrWj9AlbWiMXR07WFYE82C9axjntYyBSw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-darwin-arm64": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-arm64/-/binding-darwin-arm64-0.133.0.tgz",
-      "integrity": "sha512-4hGgKOG+dZSN3xjcgNWpcihekRG7/YbbAdjyz07yv0HjzA6kdqYAhGrn84374UPO2h6etYJwsCBoM9iJHHvJ8w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-darwin-x64": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-x64/-/binding-darwin-x64-0.133.0.tgz",
-      "integrity": "sha512-7J11/9PFkznmKuANkCAjt3znV1BcDFXQSgDiBvDxXT3Wm6995/zxrJD5zmo+5XSgY4sm+2V8/ED6ZSD3mKOC5A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-freebsd-x64": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-freebsd-x64/-/binding-freebsd-x64-0.133.0.tgz",
-      "integrity": "sha512-5EMAO0vzCpUfhn6aSjIUeJeRI2ztevHwSVr/M8sZ2VBYc79UuOfjjMCQ67LtUbgpvQtpBWkzeAHCP3L7JFYmlg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-linux-arm-gnueabihf": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.133.0.tgz",
-      "integrity": "sha512-z6XT8tmo9sPmCIYaFIxDelBU4wXLwwWMX2VNCMIY6bkQp5r+kRtVXYS3yLbJHMKEhRKvw/g+Z7fO9aadsGGEAw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-linux-arm-musleabihf": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.133.0.tgz",
-      "integrity": "sha512-GQDpEV2VhHG8hT5BviDv+emi9oHYhfv+JJJWROYp+eGgWjiQMp4QZVb6Bu3kwVMzkwy0r200ToA1KThYTq53ug==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-linux-arm64-gnu": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.133.0.tgz",
-      "integrity": "sha512-VstR+NEQAJb80ysWk2vPjEvg0JzwEjKn2hDbC/joa5zGXkCnVVCWgAGG8c6o23S981a7XRpCMcClBgeD1q9H2A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-linux-arm64-musl": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.133.0.tgz",
-      "integrity": "sha512-Ec7xJdDrnukgiz20E3iDNzAIgx1XXn8cVVsNNUpgEIAvNlXZaocqlQT8Zalk0Lv3fbkxcJ+9BuWB0ndBRHQtzg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-linux-ppc64-gnu": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.133.0.tgz",
-      "integrity": "sha512-6YX38grimcigz20eYpyz6e4c9rDKzwK3i+tcDpgwYj0bWreaAOwrABmSmKplPJOorkDVlbT69wPCN+d11irBQw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-linux-riscv64-gnu": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.133.0.tgz",
-      "integrity": "sha512-WxMIzItRJR66lgaAyyqj0FFwLMpcuCV9mTFcUMQpIz8+Hey1Enk8xuv+7QpSsqCR5zRlwNr092dsFkz5cbvtrw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-linux-riscv64-musl": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.133.0.tgz",
-      "integrity": "sha512-+x6dnO87986rjVNjcF0tg8wVS0e/SH8nzLa/X0Wsh7jtEniN7buvR8iqZm8pnsfaZ8DH5F4GCSZpoPRrd9jJ6w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-linux-s390x-gnu": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.133.0.tgz",
-      "integrity": "sha512-oEyQudXIwWM/+v0vZzPbAi25YMWyvjtQYYjuSrhMEQwe7ZEMDXscX7U1j6alrVdZq2DtCMeror3X/Dv7p/JUwg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-linux-x64-gnu": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.133.0.tgz",
-      "integrity": "sha512-G8P/OadKTbyUHz5TK63sDDtUHwn2SXG/o0oGo4GGTzBu70xmUSN5/ZUgpyl6ypAmbshoyw8nC7+msb3BjzHxaA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-linux-x64-musl": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-musl/-/binding-linux-x64-musl-0.133.0.tgz",
-      "integrity": "sha512-Oi/fyOzZ+aytmmsRND5pGgvux4n++v9cG4qNFiXj7qFwSqBKWZHBq7cJLXqbH1I81pyI3kvU1Za+1qk3afXuwg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-openharmony-arm64": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-openharmony-arm64/-/binding-openharmony-arm64-0.133.0.tgz",
-      "integrity": "sha512-/ZElgq+/tcga27X2G2AUpxcYX0baX94Gz658w6Zz2P+6Kr06bfYSrdtC0P7oPrbu3Gy/6kpiSoJPgZy8R2IjYQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-wasm32-wasi": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-wasm32-wasi/-/binding-wasm32-wasi-0.133.0.tgz",
-      "integrity": "sha512-GANcoEa8Nzza7saxdb4qWO24U6jk4nK6G+g87lGp8TTU45CUvWf1Igdze2+NrebgiwOy6F1/h6Esag4DM3JTtQ==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-win32-arm64-msvc": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.133.0.tgz",
-      "integrity": "sha512-2+uDo/+ZvGQu10J8xryg/l5PdBt2vXPtf+0aIosVKJavqCaKcBDdo95OUaEulx0bqvoytAQ4yyz2gcPZ40mjcQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-win32-ia32-msvc": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.133.0.tgz",
-      "integrity": "sha512-zpPIZ1S3JHmSEFyyGyPYCwhOiNLyfaPifYxK8BQY21JXyHglu/wUr3/ESFrXb+XegEy/iBlWbzr3FzPtcq1MUw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/@oxc-transform/binding-win32-x64-msvc": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.133.0.tgz",
-      "integrity": "sha512-cADrfLvc/VeyvpvQS+t5ktqfyqyyGANZC5NHp++JAElacfXqq/+k8bYkjqMWzNZ3HxkJtL1qDHfZZCA9+4hlSQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/nuxt/node_modules/cookie-es": {
@@ -18944,77 +17824,24 @@
         "unplugin": "^3.0.0"
       }
     },
-    "node_modules/nuxt/node_modules/oxc-parser": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.133.0.tgz",
-      "integrity": "sha512-661RSx+ZcjBmjBYid+Fpp/2F5EbtildpeoZh5HdgnGs+jZ03nqQEQW8yGkt4BGyOC3OMPDQQRl8M5kqD2/g6jw==",
+    "node_modules/nuxt/node_modules/magic-regexp/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "^0.133.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      },
-      "optionalDependencies": {
-        "@oxc-parser/binding-android-arm-eabi": "0.133.0",
-        "@oxc-parser/binding-android-arm64": "0.133.0",
-        "@oxc-parser/binding-darwin-arm64": "0.133.0",
-        "@oxc-parser/binding-darwin-x64": "0.133.0",
-        "@oxc-parser/binding-freebsd-x64": "0.133.0",
-        "@oxc-parser/binding-linux-arm-gnueabihf": "0.133.0",
-        "@oxc-parser/binding-linux-arm-musleabihf": "0.133.0",
-        "@oxc-parser/binding-linux-arm64-gnu": "0.133.0",
-        "@oxc-parser/binding-linux-arm64-musl": "0.133.0",
-        "@oxc-parser/binding-linux-ppc64-gnu": "0.133.0",
-        "@oxc-parser/binding-linux-riscv64-gnu": "0.133.0",
-        "@oxc-parser/binding-linux-riscv64-musl": "0.133.0",
-        "@oxc-parser/binding-linux-s390x-gnu": "0.133.0",
-        "@oxc-parser/binding-linux-x64-gnu": "0.133.0",
-        "@oxc-parser/binding-linux-x64-musl": "0.133.0",
-        "@oxc-parser/binding-openharmony-arm64": "0.133.0",
-        "@oxc-parser/binding-wasm32-wasi": "0.133.0",
-        "@oxc-parser/binding-win32-arm64-msvc": "0.133.0",
-        "@oxc-parser/binding-win32-ia32-msvc": "0.133.0",
-        "@oxc-parser/binding-win32-x64-msvc": "0.133.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/nuxt/node_modules/oxc-transform": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/oxc-transform/-/oxc-transform-0.133.0.tgz",
-      "integrity": "sha512-9lt2b+hkG6yqe0fUDMHhMk7rgI9uTjNxU9wauQiYnHzc4kZI8JP/OhBqXTIJQTrqRJ8CkSH3O5AhQ13ke28yNg==",
+    "node_modules/nuxt/node_modules/magic-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.0.0.tgz",
+      "integrity": "sha512-CGvjzMN08iv6w1mm4/x3Gh1hLb4VnyRUA15FFpl6CsCIGGoe36k7kY5KNz9QDbSBN5I/fWHM6ZlIkUTa5xdUEA==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      },
-      "optionalDependencies": {
-        "@oxc-transform/binding-android-arm-eabi": "0.133.0",
-        "@oxc-transform/binding-android-arm64": "0.133.0",
-        "@oxc-transform/binding-darwin-arm64": "0.133.0",
-        "@oxc-transform/binding-darwin-x64": "0.133.0",
-        "@oxc-transform/binding-freebsd-x64": "0.133.0",
-        "@oxc-transform/binding-linux-arm-gnueabihf": "0.133.0",
-        "@oxc-transform/binding-linux-arm-musleabihf": "0.133.0",
-        "@oxc-transform/binding-linux-arm64-gnu": "0.133.0",
-        "@oxc-transform/binding-linux-arm64-musl": "0.133.0",
-        "@oxc-transform/binding-linux-ppc64-gnu": "0.133.0",
-        "@oxc-transform/binding-linux-riscv64-gnu": "0.133.0",
-        "@oxc-transform/binding-linux-riscv64-musl": "0.133.0",
-        "@oxc-transform/binding-linux-s390x-gnu": "0.133.0",
-        "@oxc-transform/binding-linux-x64-gnu": "0.133.0",
-        "@oxc-transform/binding-linux-x64-musl": "0.133.0",
-        "@oxc-transform/binding-openharmony-arm64": "0.133.0",
-        "@oxc-transform/binding-wasm32-wasi": "0.133.0",
-        "@oxc-transform/binding-win32-arm64-msvc": "0.133.0",
-        "@oxc-transform/binding-win32-ia32-msvc": "0.133.0",
-        "@oxc-transform/binding-win32-x64-msvc": "0.133.0"
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/nuxt/node_modules/oxc-walker": {
@@ -19040,9 +17867,9 @@
       }
     },
     "node_modules/nuxt/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -19053,9 +17880,9 @@
       }
     },
     "node_modules/nypm": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.7.tgz",
-      "integrity": "sha512-s3ds97SD5pd1dULE+tHUk1DrV0cSHOnsfpcdGATJ8JpBo21DoKqN9exTH4/2nhPQNOLomBdTFMicN94S4DrZrQ==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.8.tgz",
+      "integrity": "sha512-Q9K4Diu6l5u6xJQogeFSs/zKtyMSgFKFtRQV+tHP4kL7KPm2grpBU0dFIwFaXwNxN0MtfKWc43VpCugAa+LPsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19081,6 +17908,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
       "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-identity": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/object-identity/-/object-identity-0.2.3.tgz",
+      "integrity": "sha512-2J8Joz2Tf7aaylhqFvIUJHNgpuGR38Hh75Voq9GzTbStBxJUaOtN0K1aOd3cV5qp+ij1pMqRbPrGCGMOyX303w==",
       "dev": true,
       "license": "MIT"
     },
@@ -19129,9 +17963,9 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -19259,49 +18093,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/oxc-minify": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.133.0.tgz",
-      "integrity": "sha512-6bNsYU+5WNIaNHB16zHnL24cUaJuKiPzUvjENoMale3+U8ZBMbGYgdgt//frx0ge7UcgEGIpqtukGGNPT0kxfQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      },
-      "optionalDependencies": {
-        "@oxc-minify/binding-android-arm-eabi": "0.133.0",
-        "@oxc-minify/binding-android-arm64": "0.133.0",
-        "@oxc-minify/binding-darwin-arm64": "0.133.0",
-        "@oxc-minify/binding-darwin-x64": "0.133.0",
-        "@oxc-minify/binding-freebsd-x64": "0.133.0",
-        "@oxc-minify/binding-linux-arm-gnueabihf": "0.133.0",
-        "@oxc-minify/binding-linux-arm-musleabihf": "0.133.0",
-        "@oxc-minify/binding-linux-arm64-gnu": "0.133.0",
-        "@oxc-minify/binding-linux-arm64-musl": "0.133.0",
-        "@oxc-minify/binding-linux-ppc64-gnu": "0.133.0",
-        "@oxc-minify/binding-linux-riscv64-gnu": "0.133.0",
-        "@oxc-minify/binding-linux-riscv64-musl": "0.133.0",
-        "@oxc-minify/binding-linux-s390x-gnu": "0.133.0",
-        "@oxc-minify/binding-linux-x64-gnu": "0.133.0",
-        "@oxc-minify/binding-linux-x64-musl": "0.133.0",
-        "@oxc-minify/binding-openharmony-arm64": "0.133.0",
-        "@oxc-minify/binding-wasm32-wasi": "0.133.0",
-        "@oxc-minify/binding-win32-arm64-msvc": "0.133.0",
-        "@oxc-minify/binding-win32-ia32-msvc": "0.133.0",
-        "@oxc-minify/binding-win32-x64-msvc": "0.133.0"
-      }
-    },
     "node_modules/oxc-parser": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.128.0.tgz",
-      "integrity": "sha512-XkOw3eiIxAgQ19WRew/Bq9wc5Ga/guaWIzDBzq80z1PyuDNGvWBpPby9k6YGwV8A8uMw+Nlq3xqlzuDYmUFYUw==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.140.0.tgz",
+      "integrity": "sha512-h6QFWd6lBMfjESqgQ27GjzrSDb0qbznp7VDQqp2zvgsrWut4vcchyMIzOVXvGQ2GMZgKw9RWrFNWv9WqGL0p7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "^0.128.0"
+        "@oxc-project/types": "^0.140.0"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -19310,26 +18109,26 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-parser/binding-android-arm-eabi": "0.128.0",
-        "@oxc-parser/binding-android-arm64": "0.128.0",
-        "@oxc-parser/binding-darwin-arm64": "0.128.0",
-        "@oxc-parser/binding-darwin-x64": "0.128.0",
-        "@oxc-parser/binding-freebsd-x64": "0.128.0",
-        "@oxc-parser/binding-linux-arm-gnueabihf": "0.128.0",
-        "@oxc-parser/binding-linux-arm-musleabihf": "0.128.0",
-        "@oxc-parser/binding-linux-arm64-gnu": "0.128.0",
-        "@oxc-parser/binding-linux-arm64-musl": "0.128.0",
-        "@oxc-parser/binding-linux-ppc64-gnu": "0.128.0",
-        "@oxc-parser/binding-linux-riscv64-gnu": "0.128.0",
-        "@oxc-parser/binding-linux-riscv64-musl": "0.128.0",
-        "@oxc-parser/binding-linux-s390x-gnu": "0.128.0",
-        "@oxc-parser/binding-linux-x64-gnu": "0.128.0",
-        "@oxc-parser/binding-linux-x64-musl": "0.128.0",
-        "@oxc-parser/binding-openharmony-arm64": "0.128.0",
-        "@oxc-parser/binding-wasm32-wasi": "0.128.0",
-        "@oxc-parser/binding-win32-arm64-msvc": "0.128.0",
-        "@oxc-parser/binding-win32-ia32-msvc": "0.128.0",
-        "@oxc-parser/binding-win32-x64-msvc": "0.128.0"
+        "@oxc-parser/binding-android-arm-eabi": "0.140.0",
+        "@oxc-parser/binding-android-arm64": "0.140.0",
+        "@oxc-parser/binding-darwin-arm64": "0.140.0",
+        "@oxc-parser/binding-darwin-x64": "0.140.0",
+        "@oxc-parser/binding-freebsd-x64": "0.140.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.140.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.140.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.140.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.140.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.140.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.140.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.140.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.140.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.140.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.140.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.140.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.140.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.140.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.140.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.140.0"
       }
     },
     "node_modules/oxc-transform": {
@@ -19449,9 +18248,9 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/package-manager-detector": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
-      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.7.0.tgz",
+      "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -19637,9 +18436,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -19677,9 +18476,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -19722,9 +18521,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
       "funding": [
         {
           "type": "opencollective",
@@ -19741,7 +18540,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -20320,9 +19119,9 @@
       }
     },
     "node_modules/pretty-bytes": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-7.1.0.tgz",
-      "integrity": "sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-7.1.1.tgz",
+      "integrity": "sha512-X+vn9z8nOFZQlxOLmfJ0iKDdMD7jYTsTW12OAlCpdoE3Igik6L37pugIZi+N3usuyp5McfgKPWi12q3zvHLeGQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20424,13 +19223,17 @@
       "license": "MIT"
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/rc9": {
@@ -20479,9 +19282,9 @@
       "license": "MIT"
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20853,14 +19656,13 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.0.tgz",
+      "integrity": "sha512-u7tgm5l4Yw1iTqUL4EcYOAt7fFvCgQMLeidrnD4GALlC6aOznCjezYajgxeyKw27u0Q5N7fwgCzjVyPIWzwuBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@oxc-project/types": "=0.133.0",
+        "@oxc-project/types": "=0.140.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -20870,38 +19672,61 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.3",
-        "@rolldown/binding-darwin-arm64": "1.0.3",
-        "@rolldown/binding-darwin-x64": "1.0.3",
-        "@rolldown/binding-freebsd-x64": "1.0.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-        "@rolldown/binding-linux-arm64-musl": "1.0.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-musl": "1.0.3",
-        "@rolldown/binding-openharmony-arm64": "1.0.3",
-        "@rolldown/binding-wasm32-wasi": "1.0.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+        "@rolldown/binding-android-arm64": "1.2.0",
+        "@rolldown/binding-darwin-arm64": "1.2.0",
+        "@rolldown/binding-darwin-x64": "1.2.0",
+        "@rolldown/binding-freebsd-x64": "1.2.0",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.0",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.0",
+        "@rolldown/binding-linux-arm64-musl": "1.2.0",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.0",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.0",
+        "@rolldown/binding-linux-x64-gnu": "1.2.0",
+        "@rolldown/binding-linux-x64-musl": "1.2.0",
+        "@rolldown/binding-openharmony-arm64": "1.2.0",
+        "@rolldown/binding-wasm32-wasi": "1.2.0",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.0",
+        "@rolldown/binding-win32-x64-msvc": "1.2.0"
       }
     },
-    "node_modules/rolldown/node_modules/@oxc-project/types": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+    "node_modules/rolldown-string": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/rolldown-string/-/rolldown-string-0.3.1.tgz",
+      "integrity": "sha512-dv8GOXkYqUQdI0rsXB8hmzO95pKWSuX2eg5/JSJa9czfEVIFuKNR7ZJDfat8LlmD35RAhWY+evS7/wXXqFDfSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
+      "dependencies": {
+        "magic-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
       "funding": {
-        "url": "https://github.com/sponsors/Boshen"
+        "url": "https://github.com/sponsors/sxzz"
+      },
+      "peerDependencies": {
+        "rolldown": "*"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rolldown-string/node_modules/magic-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.0.0.tgz",
+      "integrity": "sha512-CGvjzMN08iv6w1mm4/x3Gh1hLb4VnyRUA15FFpl6CsCIGGoe36k7kY5KNz9QDbSBN5I/fWHM6ZlIkUTa5xdUEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/rollup": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
-      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20915,31 +19740,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.62.0",
-        "@rollup/rollup-android-arm64": "4.62.0",
-        "@rollup/rollup-darwin-arm64": "4.62.0",
-        "@rollup/rollup-darwin-x64": "4.62.0",
-        "@rollup/rollup-freebsd-arm64": "4.62.0",
-        "@rollup/rollup-freebsd-x64": "4.62.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
-        "@rollup/rollup-linux-arm64-musl": "4.62.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
-        "@rollup/rollup-linux-loong64-musl": "4.62.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
-        "@rollup/rollup-linux-x64-gnu": "4.62.0",
-        "@rollup/rollup-linux-x64-musl": "4.62.0",
-        "@rollup/rollup-openbsd-x64": "4.62.0",
-        "@rollup/rollup-openharmony-arm64": "4.62.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
-        "@rollup/rollup-win32-x64-gnu": "4.62.0",
-        "@rollup/rollup-win32-x64-msvc": "4.62.0",
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -20985,9 +19810,9 @@
       }
     },
     "node_modules/rou3": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.8.1.tgz",
-      "integrity": "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.9.1.tgz",
+      "integrity": "sha512-z/sSmzvtwMDDnxsPVhfWMuG6F6mbmhFDXoVqLmMfbpDD9qfV3GDmSQpf0+W296/ZDIpW2wcMmBfpVFzcnOi/nA==",
       "dev": true,
       "license": "MIT"
     },
@@ -21048,13 +19873,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-array-concat/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -21092,13 +19910,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/safe-push-apply/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
@@ -21207,9 +20018,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
-      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -21217,9 +20028,9 @@
       }
     },
     "node_modules/seroval": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.4.tgz",
-      "integrity": "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.6.tgz",
+      "integrity": "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -21359,9 +20170,9 @@
       }
     },
     "node_modules/sharp/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "optional": true,
@@ -21396,9 +20207,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -21648,9 +20459,9 @@
       "license": "MIT"
     },
     "node_modules/srvx": {
-      "version": "0.11.16",
-      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.16.tgz",
-      "integrity": "sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==",
+      "version": "0.11.22",
+      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.22.tgz",
+      "integrity": "sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -21688,9 +20499,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -21738,9 +20549,9 @@
       "license": "MIT"
     },
     "node_modules/string-width": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22067,9 +20878,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22157,9 +20968,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
-      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -22176,9 +20987,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -22281,9 +21092,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
-      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -22334,9 +21145,9 @@
       "license": "MIT"
     },
     "node_modules/tinyclip": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.14.tgz",
-      "integrity": "sha512-F1oWdz8tjT17qe1d5JgDK6z03WGOhYYAN0lK3/D/fzNiy93xswLLEw7pk+3g05onhAy6Bsc6PLNUGhdgVjemMQ==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.15.tgz",
+      "integrity": "sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -22490,9 +21301,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
-      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
@@ -22612,9 +21423,9 @@
       "license": "MIT"
     },
     "node_modules/ultrahtml": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.6.0.tgz",
-      "integrity": "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.7.0.tgz",
+      "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
       "dev": true,
       "license": "MIT"
     },
@@ -22655,48 +21466,46 @@
       "license": "MIT"
     },
     "node_modules/unctx": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.5.0.tgz",
-      "integrity": "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.0.tgz",
+      "integrity": "sha512-DoXdZVeyi2jyEsn86i8MO5RTItm1kffUkH9/+DQORn3Q688AMOy2551CIl6AdGL2UpwD675wtbNOl75wIQN/uA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21",
-        "unplugin": "^2.3.11"
-      }
-    },
-    "node_modules/unctx/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/unctx/node_modules/unplugin": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
-      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/remapping": "^2.3.5",
-        "acorn": "^8.15.0",
-        "picomatch": "^4.0.3",
-        "webpack-virtual-modules": "^0.6.2"
+      "peerDependencies": {
+        "magic-string": ">=0.30.21",
+        "oxc-parser": ">=0.140.0",
+        "rolldown": "^1.1.5",
+        "unplugin": "^3.3.0"
       },
+      "peerDependenciesMeta": {
+        "magic-string": {
+          "optional": true
+        },
+        "oxc-parser": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        },
+        "unplugin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.8.0.tgz",
+      "integrity": "sha512-ubshXMXwF3MQIMF1y/WxZdNBnjEKeSg2wF5mcGUtU55YTw34tnVVpKRlLf7ruDXZ5344KokPVX4RBx1wJm64Bw==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -22711,16 +21520,25 @@
       }
     },
     "node_modules/unhead": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.15.tgz",
-      "integrity": "sha512-MCt5T90mCWyr3Z6pUCdM9lVRXoMoVBlL7z7U4CYVIiaDiuzad/UCfLuMqz5MeNmpZUgoBCQnrucJimU7EZR+XA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-3.2.1.tgz",
+      "integrity": "sha512-Z7VNRf0QJlRZmwA1p5gsnmKYkjnbvV/CXdJAL+VMDmMF+RS2P4FqLouEhBA6WOuKPe3ZZ8EZgX2zQm7ZkAGDPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hookable": "^6.0.1"
+        "hookable": "^6.1.1",
+        "unplugin": "^3.3.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "vite": ">=6.4.2"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -22781,9 +21599,9 @@
       }
     },
     "node_modules/unimport": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/unimport/-/unimport-6.3.0.tgz",
-      "integrity": "sha512-M+Dxk5W9WRd+8j56W9tp8lGW/dmMc7g5zj7BWQnEjKQhryBstqsi1V0izb0zHwSkEN8cSYV7K75/bykairV2tA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/unimport/-/unimport-6.3.1.tgz",
+      "integrity": "sha512-43BV4iELfhpZ0JNSedMNdBqomAIaJwBrmTqIUYRb8ly3XVQihcRPAVIOSwb23XVCJgtjSf+f82d5Qpdsxqh8iQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22891,29 +21709,69 @@
       }
     },
     "node_modules/unplugin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
-      "integrity": "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
+      "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.4",
         "webpack-virtual-modules": "^0.6.2"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@farmfe/core": "*",
+        "@rspack/core": "*",
+        "bun-types-no-globals": "*",
+        "esbuild": "*",
+        "rolldown": "*",
+        "rollup": "*",
+        "unloader": "*",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "@farmfe/core": {
+          "optional": true
+        },
+        "@rspack/core": {
+          "optional": true
+        },
+        "bun-types-no-globals": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "unloader": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/unplugin-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.1.tgz",
-      "integrity": "sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.2.tgz",
+      "integrity": "sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -23082,9 +21940,9 @@
       }
     },
     "node_modules/unstorage/node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -23092,26 +21950,14 @@
       }
     },
     "node_modules/untun": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/untun/-/untun-0.1.3.tgz",
-      "integrity": "sha512-4luGP9LMYszMRZwsvyUd9MrxgEGZdZuZgpVQHEEX0lCYFESasVRvZd0EYpCkOIbJKHMuv0LskpXc/8Un+MJzEQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/untun/-/untun-0.2.2.tgz",
+      "integrity": "sha512-+NnOJcSiEtYsVgJmXUzQbJeRAFXJC4yPJYuh6kF9B0Rm6zunXcs/3GZOTllyocSbUDIxD6Bj7e/4ATw7sph1Sw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "citty": "^0.1.5",
-        "consola": "^3.2.3",
-        "pathe": "^1.1.1"
-      },
       "bin": {
-        "untun": "bin/untun.mjs"
+        "untun": "dist/cli.mjs"
       }
-    },
-    "node_modules/untun/node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/untyped": {
       "version": "2.0.0",
@@ -23239,9 +22085,9 @@
       "license": "MIT"
     },
     "node_modules/valibot": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.1.tgz",
-      "integrity": "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
+      "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -23254,17 +22100,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "1.0.3",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -23281,7 +22126,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
+        "@vitejs/devtools": "^0.3.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -23363,17 +22208,17 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-5.3.0.tgz",
-      "integrity": "sha512-8f20COPYJujc3OKPX6OuyBy3ZIv2det4eRRU4GY1y2MjbeGSUmPjedxg1b72KnTagCofwvZ65ThzjxDW2AtQFQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-6.0.0.tgz",
+      "integrity": "sha512-oj4PVrT+pDh6GYf5wfUXkcZyekYS8kKPfLPXVl8qe324Ec6l4K2DUKNadRbZ3LQl0qGcDz+PyOo7ZAh00Y+JjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cac": "^6.7.14",
+        "cac": "^7.0.0",
         "es-module-lexer": "^2.0.0",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
-        "vite": "^7.3.1"
+        "vite": "^8.0.0"
       },
       "bin": {
         "vite-node": "dist/cli.mjs"
@@ -23385,579 +22230,10 @@
         "url": "https://opencollective.com/antfu"
       }
     },
-    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/vite-node/node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
-      }
-    },
-    "node_modules/vite-node/node_modules/vite": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
-      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/vite-plugin-checker": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.14.1.tgz",
-      "integrity": "sha512-Mv8oQc9XYBYf+XkP/riqqQCt8lBP6Iad75PZPho1lHRrpxQI0BwX2gwE10enn4f6Hgc+PvR1F7N38KARcaJtzw==",
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.14.4.tgz",
+      "integrity": "sha512-Tw0U9UgHIRiZ+Yoe4Gh0RrYoBiCVmO9j4tomVdYr0KUjUsqXMPhqW8ouoSWmOzGp5Iimipbl3bNXZcK7OeP7Qg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -24147,6 +22423,341 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/vite/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/vite/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/vite/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/vite/node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -24155,16 +22766,16 @@
       "license": "MIT"
     },
     "node_modules/vue": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.38.tgz",
-      "integrity": "sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==",
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.40.tgz",
+      "integrity": "sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.38",
-        "@vue/compiler-sfc": "3.5.38",
-        "@vue/runtime-dom": "3.5.38",
-        "@vue/server-renderer": "3.5.38",
-        "@vue/shared": "3.5.38"
+        "@vue/compiler-dom": "3.5.40",
+        "@vue/compiler-sfc": "3.5.40",
+        "@vue/runtime-dom": "3.5.40",
+        "@vue/server-renderer": "3.5.40",
+        "@vue/shared": "3.5.40"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -24176,13 +22787,13 @@
       }
     },
     "node_modules/vue-bundle-renderer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/vue-bundle-renderer/-/vue-bundle-renderer-2.2.0.tgz",
-      "integrity": "sha512-sz/0WEdYH1KfaOm0XaBmRZOWgYTEvUDt6yPYaUzl4E52qzgWLlknaPPTTZmp6benaPTlQAI/hN1x3tAzZygycg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/vue-bundle-renderer/-/vue-bundle-renderer-2.3.1.tgz",
+      "integrity": "sha512-7F4LNMopUw5RgYWo4zCmVUHCc6aQRC6dCKHUYkM/n+fux4AUGdL1x6m5A515WWyFysRRN7cx3hBzVqoisfRfzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ufo": "^1.6.1"
+        "ufo": "^1.6.4"
       }
     },
     "node_modules/vue-devtools-stub": {
@@ -24230,9 +22841,9 @@
       }
     },
     "node_modules/vue-eslint-parser/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -24243,15 +22854,15 @@
       }
     },
     "node_modules/vue-i18n": {
-      "version": "11.4.5",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.4.5.tgz",
-      "integrity": "sha512-rm8YJ6RpjOrkcgS2GLrZwLvs/VbhxbTSuEspbyXDo233+fPK0OMFNLOj3fdQYVKdOgcpSfLW91JhbqgpkkcBWA==",
+      "version": "11.4.7",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.4.7.tgz",
+      "integrity": "sha512-j6RyshdPPzqLiMAUpnpvZGFPM+rRoWi14Sl5yTsquvoW0/56DWyvhAj2o9TO2YXGvb6teg8T0xrYO9jR3urvdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@intlify/core-base": "11.4.5",
-        "@intlify/devtools-types": "11.4.5",
-        "@intlify/shared": "11.4.5",
+        "@intlify/core-base": "11.4.7",
+        "@intlify/devtools-types": "11.4.7",
+        "@intlify/shared": "11.4.7",
         "@vue/devtools-api": "^6.5.0"
       },
       "engines": {
@@ -24265,28 +22876,29 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.1.0.tgz",
-      "integrity": "sha512-HAbiLzLEHQwxPgvsbOJDAwtavszEgLwri6XfyrsPECIFez8+59xc9LofWVdc/HEaSRT822lJ8H9Ns38VVond5g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.2.0.tgz",
+      "integrity": "sha512-QAC5i0LEb1GLG0LXDQmHu8L7FX12j0KwU/JTKmLQUJMrn04gQdKP6Du+p0QwpHb3iy71vBlqnHQ8WAfOSAWhqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/generator": "^8.0.0-rc.4",
-        "@vue-macros/common": "^3.1.1",
-        "@vue/devtools-api": "^8.1.2",
+        "@babel/generator": "^8.0.0",
+        "@vue-macros/common": "^3.1.3",
+        "@vue/devtools-api": "^8.1.5",
         "ast-walker-scope": "^0.9.0",
         "chokidar": "^5.0.0",
         "json5": "^2.2.3",
-        "local-pkg": "^1.1.2",
+        "local-pkg": "^1.2.1",
         "magic-string": "^0.30.21",
         "mlly": "^1.8.2",
         "muggle-string": "^0.4.1",
+        "nostics": "^1.1.4",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.5",
         "scule": "^1.3.0",
-        "tinyglobby": "^0.2.16",
-        "unplugin": "^3.0.0",
-        "unplugin-utils": "^0.3.1",
+        "tinyglobby": "^0.2.17",
+        "unplugin": "^3.3.0",
+        "unplugin-utils": "^0.3.2",
         "yaml": "^2.9.0"
       },
       "funding": {
@@ -24294,10 +22906,10 @@
       },
       "peerDependencies": {
         "@pinia/colada": ">=0.21.2",
-        "@vue/compiler-sfc": "^3.5.34",
-        "pinia": "^3.0.4",
-        "vite": "^7.0.0 || ^8.0.0",
-        "vue": "^3.5.34"
+        "@vue/compiler-sfc": "^3.5.34 || ^4.0.0",
+        "pinia": "^3.0.4 || ^4.0.2",
+        "vite": "^7.3.0 || ^8.0.0",
+        "vue": "^3.5.34 || ^4.0.0"
       },
       "peerDependenciesMeta": {
         "@pinia/colada": {
@@ -24315,81 +22927,81 @@
       }
     },
     "node_modules/vue-router/node_modules/@babel/generator": {
-      "version": "8.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0-rc.4.tgz",
-      "integrity": "sha512-YZ+FuIgkj7KrIb2a2X1XiY0QYgDxAbVbYP64SjwJzOK3euCsUerzenh2oqdsmKuPSlhzmFOOklnxzHAzXagvpw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^8.0.0-rc.4",
-        "@babel/types": "^8.0.0-rc.4",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "@types/jsesc": "^2.5.0",
         "jsesc": "^3.0.2"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/vue-router/node_modules/@babel/helper-string-parser": {
-      "version": "8.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.4.tgz",
-      "integrity": "sha512-dluR3v287dp6YPF57kyKKrHPKffUeuxH1zQcF1WD30TeFzWXhDiVi1U6PkqaDB0++H1PeCwRhmYl4DvoerlPIw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/vue-router/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.4.tgz",
-      "integrity": "sha512-HTD3bskipk5MSm08twTW6832jzIXUhxMddy4NPPzIMuyMEsrs0ZgwAaMj5ubB5+6hMlUjDu17vNconEmwsmpYg==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/vue-router/node_modules/@babel/parser": {
-      "version": "8.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.4.tgz",
-      "integrity": "sha512-0S/1yefMa15N4i2v3t8Fw9pgMHhf2gF6Lc1UEXI96Ls6FNAjqvHHZouZ2ZS/deqLhbMFtmfVeFac6iTsvFbLwA==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^8.0.0-rc.4"
+        "@babel/types": "^8.0.4"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/vue-router/node_modules/@babel/types": {
-      "version": "8.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.4.tgz",
-      "integrity": "sha512-bw30DV880P/VYtsjWWdoWmJpb9S2Vn1/PqayyccTELzRQ/HslIO7+BD9rNoZ4AAFOAjC1vrNeBCkAsyh6Ibfww==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^8.0.0-rc.4",
-        "@babel/helper-validator-identifier": "^8.0.0-rc.4"
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/vue-router/node_modules/@vue/devtools-api": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.3.tgz",
-      "integrity": "sha512-73NMCvxXh8Hyozc/jiwqTFWVcCMyi11U1zmrq4DoukQJnuo8JHt6FsNu4HdeUDa8SpIp5vb7Q22GWgIq0efsXg==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.5.tgz",
+      "integrity": "sha512-YJipMVAKe5wT5CWf5kTYCaNV7NMNjFVxJkIkJaJ4W/nCxEBzlZzrOsYKeCymdCrFZmBS/+wTWFoUs3Jf/Q6XSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-kit": "^8.1.3"
+        "@vue/devtools-kit": "^8.1.5"
       }
     },
     "node_modules/vue-tsc": {
@@ -24517,13 +23129,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/which-builtin-type/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/which-collection": {
       "version": "1.0.2",
@@ -24663,6 +23268,16 @@
         "ajv": ">=8"
       }
     },
+    "node_modules/workbox-build/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/workbox-build/node_modules/@isaacs/cliui": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
@@ -24752,46 +23367,13 @@
       }
     },
     "node_modules/workbox-build/node_modules/source-map": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-      "deprecated": "The work that was done in this beta branch won't be included in future versions",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0.tgz",
+      "integrity": "sha512-d8EqvL+k/SOXCreS/SUzg2ciyHqBBLcN/yuRjFsbvVhHTE2pgei7oAhmPM7kWFbkX6OSMQfUq4KbkF3au9lhYQ==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "whatwg-url": "^7.0.0"
-      },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/workbox-build/node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/workbox-build/node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/workbox-build/node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "node": ">= 12"
       }
     },
     "node_modules/workbox-cacheable-response": {
@@ -25033,9 +23615,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -25072,13 +23654,13 @@
       }
     },
     "node_modules/xml-name-validator": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/xss": {

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
   "devDependencies": {
     "@graphql-codegen/add": "^7.1.0",
     "@graphql-codegen/cli": "^7.2.0",
-    "@graphql-codegen/typescript": "^6.1.0",
+    "@graphql-codegen/typescript": "5.0.10",
     "@graphql-codegen/typescript-graphql-request": "^7.1.0",
-    "@graphql-codegen/typescript-operations": "^6.1.1",
+    "@graphql-codegen/typescript-operations": "5.1.0",
     "@iconify-json/ion": "^1.2.7",
     "@nuxt/eslint": "^1.16.0",
     "@nuxt/icon": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "@stripe/stripe-js": "^9.10.0",
+    "@stripe/stripe-js": "^9.12.0",
     "@tailwindcss/vite": "^4.3.3",
     "@vueuse/core": "^14.3.0",
     "graphql": "^16.14.2",

--- a/package.json
+++ b/package.json
@@ -19,21 +19,21 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "@stripe/stripe-js": "^9.9.0",
-    "@tailwindcss/postcss": "^4.3.2",
+    "@stripe/stripe-js": "^9.10.0",
+    "@tailwindcss/postcss": "^4.3.3",
     "@vueuse/core": "^14.3.0",
     "graphql": "^16.14.2",
     "graphql-request": "^7.4.0",
     "reka-ui": "^2.10.1",
     "tailwind-merge": "^3.6.0",
-    "tailwindcss": "^4.3.2"
+    "tailwindcss": "^4.3.3"
   },
   "devDependencies": {
     "@graphql-codegen/add": "^7.1.0",
     "@graphql-codegen/cli": "^7.2.0",
     "@graphql-codegen/typescript": "^6.1.0",
     "@graphql-codegen/typescript-graphql-request": "^7.1.0",
-    "@graphql-codegen/typescript-operations": "^6.1.0",
+    "@graphql-codegen/typescript-operations": "^6.1.1",
     "@iconify-json/ion": "^1.2.7",
     "@nuxt/eslint": "^1.16.0",
     "@nuxt/icon": "^2.3.1",
@@ -42,7 +42,7 @@
     "@tailwindcss/typography": "^0.5.20",
     "@vite-pwa/nuxt": "^1.1.1",
     "eslint": "^10.7.0",
-    "nuxt": "^4.4.8",
+    "nuxt": "^4.5.0",
     "prettier": "^3.9.5",
     "typescript": "^6.0.3",
     "vue-tsc": "^3.3.7"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@stripe/stripe-js": "^9.10.0",
-    "@tailwindcss/postcss": "^4.3.3",
+    "@tailwindcss/vite": "^4.3.3",
     "@vueuse/core": "^14.3.0",
     "graphql": "^16.14.2",
     "graphql-request": "^7.4.0",

--- a/woonuxt_base/app/assets/css/main.css
+++ b/woonuxt_base/app/assets/css/main.css
@@ -1,4 +1,4 @@
-@import 'tailwindcss';
+@import '../../../../node_modules/tailwindcss/index.css';
 @plugin '@tailwindcss/typography';
 
 /* Center container */

--- a/woonuxt_base/app/assets/css/main.css
+++ b/woonuxt_base/app/assets/css/main.css
@@ -1,4 +1,4 @@
-@import '../../../../node_modules/tailwindcss/index.css';
+@import 'tailwindcss';
 @plugin '@tailwindcss/typography';
 
 /* Center container */

--- a/woonuxt_base/app/components/generalElements/SEOHead.vue
+++ b/woonuxt_base/app/components/generalElements/SEOHead.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { ResolvableLink, ResolvableMeta, ResolvableScript } from '@unhead/vue';
 import type { ProductDetail } from '#types/gql';
 import type { SeoHeadData } from '#types/seo-provider';
 
@@ -12,9 +13,9 @@ const seoData: SeoHeadData = typeof yoastHead === 'string' && yoastHead.trim() ?
 
 useHead({
   title: seoData.title,
-  meta: seoData.meta,
-  link: seoData.link,
-  script: seoData.script.map((item) => ({ type: item.type, innerHTML: item.innerHTML })),
+  meta: seoData.meta as ResolvableMeta[],
+  link: seoData.link as ResolvableLink[],
+  script: seoData.script.map((item) => ({ type: item.type, innerHTML: item.innerHTML })) as ResolvableScript[],
 });
 </script>
 

--- a/woonuxt_base/app/gql/default.ts
+++ b/woonuxt_base/app/gql/default.ts
@@ -2,14 +2,15 @@
 // @ts-nocheck
 // This file is auto-generated. Do not edit manually — run `npm run graphql:codegen` to regenerate.
 
-/** Internal type. DO NOT USE DIRECTLY. */
-type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-/** Internal type. DO NOT USE DIRECTLY. */
-export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 import { type GraphQLClient, type RequestOptions } from 'graphql-request';
 import gql from 'graphql-tag';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 type GraphQLClientRequestHeaders = RequestOptions['requestHeaders'];
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -31696,710 +31697,123 @@ export type WritingSettings = {
   useSmilies?: Maybe<Scalars['Boolean']['output']>;
 };
 
-/** Input for the addToCart mutation. */
-export type AddToCartInput = {
-  /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: string | null | undefined;
-  /** JSON string representation of extra cart item data */
-  extraData?: string | null | undefined;
-  /** Cart item product database ID or global ID */
-  productId: number;
-  /** Cart item quantity */
-  quantity?: number | null | undefined;
-  /** Cart item product variation attributes */
-  variation?: Array<ProductAttributeInput | null | undefined> | null | undefined;
-  /** Cart item product variation database ID or global ID */
-  variationId?: number | null | undefined;
-};
-
-/** Countries enumeration */
-export type CountriesEnum =
-  | 'AD'
-  | 'AE'
-  | 'AF'
-  | 'AG'
-  | 'AI'
-  | 'AL'
-  | 'AM'
-  | 'AO'
-  | 'AQ'
-  | 'AR'
-  | 'AS'
-  | 'AT'
-  | 'AU'
-  | 'AW'
-  | 'AX'
-  | 'AZ'
-  | 'BA'
-  | 'BB'
-  | 'BD'
-  | 'BE'
-  | 'BF'
-  | 'BG'
-  | 'BH'
-  | 'BI'
-  | 'BJ'
-  | 'BL'
-  | 'BM'
-  | 'BN'
-  | 'BO'
-  | 'BQ'
-  | 'BR'
-  | 'BS'
-  | 'BT'
-  | 'BV'
-  | 'BW'
-  | 'BY'
-  | 'BZ'
-  | 'CA'
-  | 'CC'
-  | 'CD'
-  | 'CF'
-  | 'CG'
-  | 'CH'
-  | 'CI'
-  | 'CK'
-  | 'CL'
-  | 'CM'
-  | 'CN'
-  | 'CO'
-  | 'CR'
-  | 'CU'
-  | 'CV'
-  | 'CW'
-  | 'CX'
-  | 'CY'
-  | 'CZ'
-  | 'DE'
-  | 'DJ'
-  | 'DK'
-  | 'DM'
-  | 'DO'
-  | 'DZ'
-  | 'EC'
-  | 'EE'
-  | 'EG'
-  | 'EH'
-  | 'ER'
-  | 'ES'
-  | 'ET'
-  | 'FI'
-  | 'FJ'
-  | 'FK'
-  | 'FM'
-  | 'FO'
-  | 'FR'
-  | 'GA'
-  | 'GB'
-  | 'GD'
-  | 'GE'
-  | 'GF'
-  | 'GG'
-  | 'GH'
-  | 'GI'
-  | 'GL'
-  | 'GM'
-  | 'GN'
-  | 'GP'
-  | 'GQ'
-  | 'GR'
-  | 'GS'
-  | 'GT'
-  | 'GU'
-  | 'GW'
-  | 'GY'
-  | 'HK'
-  | 'HM'
-  | 'HN'
-  | 'HR'
-  | 'HT'
-  | 'HU'
-  | 'ID'
-  | 'IE'
-  | 'IL'
-  | 'IM'
-  | 'IN'
-  | 'IO'
-  | 'IQ'
-  | 'IR'
-  | 'IS'
-  | 'IT'
-  | 'JE'
-  | 'JM'
-  | 'JO'
-  | 'JP'
-  | 'KE'
-  | 'KG'
-  | 'KH'
-  | 'KI'
-  | 'KM'
-  | 'KN'
-  | 'KP'
-  | 'KR'
-  | 'KW'
-  | 'KY'
-  | 'KZ'
-  | 'LA'
-  | 'LB'
-  | 'LC'
-  | 'LI'
-  | 'LK'
-  | 'LR'
-  | 'LS'
-  | 'LT'
-  | 'LU'
-  | 'LV'
-  | 'LY'
-  | 'MA'
-  | 'MC'
-  | 'MD'
-  | 'ME'
-  | 'MF'
-  | 'MG'
-  | 'MH'
-  | 'MK'
-  | 'ML'
-  | 'MM'
-  | 'MN'
-  | 'MO'
-  | 'MP'
-  | 'MQ'
-  | 'MR'
-  | 'MS'
-  | 'MT'
-  | 'MU'
-  | 'MV'
-  | 'MW'
-  | 'MX'
-  | 'MY'
-  | 'MZ'
-  | 'NA'
-  | 'NC'
-  | 'NE'
-  | 'NF'
-  | 'NG'
-  | 'NI'
-  | 'NL'
-  | 'NO'
-  | 'NP'
-  | 'NR'
-  | 'NU'
-  | 'NZ'
-  | 'OM'
-  | 'PA'
-  | 'PE'
-  | 'PF'
-  | 'PG'
-  | 'PH'
-  | 'PK'
-  | 'PL'
-  | 'PM'
-  | 'PN'
-  | 'PR'
-  | 'PS'
-  | 'PT'
-  | 'PW'
-  | 'PY'
-  | 'QA'
-  | 'RE'
-  | 'RO'
-  | 'RS'
-  | 'RU'
-  | 'RW'
-  | 'SA'
-  | 'SB'
-  | 'SC'
-  | 'SD'
-  | 'SE'
-  | 'SG'
-  | 'SH'
-  | 'SI'
-  | 'SJ'
-  | 'SK'
-  | 'SL'
-  | 'SM'
-  | 'SN'
-  | 'SO'
-  | 'SR'
-  | 'SS'
-  | 'ST'
-  | 'SV'
-  | 'SX'
-  | 'SY'
-  | 'SZ'
-  | 'TC'
-  | 'TD'
-  | 'TF'
-  | 'TG'
-  | 'TH'
-  | 'TJ'
-  | 'TK'
-  | 'TL'
-  | 'TM'
-  | 'TN'
-  | 'TO'
-  | 'TR'
-  | 'TT'
-  | 'TV'
-  | 'TW'
-  | 'TZ'
-  | 'UA'
-  | 'UG'
-  | 'UM'
-  | 'US'
-  | 'UY'
-  | 'UZ'
-  | 'VA'
-  | 'VC'
-  | 'VE'
-  | 'VG'
-  | 'VI'
-  | 'VN'
-  | 'VU'
-  | 'WF'
-  | 'WS'
-  | 'XK'
-  | 'YE'
-  | 'YT'
-  | 'ZA'
-  | 'ZM'
-  | 'ZW';
-
-/** Customer account credentials */
-export type CreateAccountInput = {
-  /** Set the current user to the newly created customer after checkout. */
-  authenticate?: boolean | null | undefined;
-  /** Customer password */
-  password: string;
-  /** Customer username */
-  username: string;
-};
-
-/** Customer address information */
-export type CustomerAddressInput = {
-  /** Address 1 */
-  address1?: string | null | undefined;
-  /** Address 2 */
-  address2?: string | null | undefined;
-  /** City */
-  city?: string | null | undefined;
-  /** Company */
-  company?: string | null | undefined;
-  /** Country */
-  country?: CountriesEnum | null | undefined;
-  /** E-mail */
-  email?: string | null | undefined;
-  /** First name */
-  firstName?: string | null | undefined;
-  /** Last name */
-  lastName?: string | null | undefined;
-  /** Clear old address data */
-  overwrite?: boolean | null | undefined;
-  /** Phone */
-  phone?: string | null | undefined;
-  /** Zip Postal Code */
-  postcode?: string | null | undefined;
-  /** State */
-  state?: string | null | undefined;
-};
-
-/** Input for the Login mutation. */
-export type LoginInput = {
-  /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: string | null | undefined;
-  /** The WordPress user credentials. Required by the Password provider. */
-  credentials?: PasswordProviderResponseInput | null | undefined;
-  /** The user identity to use when logging in. Required by the SiteToken provider. */
-  identity?: string | null | undefined;
-  /** The parsed response from an OAuth2 Authentication Provider. */
-  oauthResponse?: OAuthProviderResponseInput | null | undefined;
-  /** The Headless Login provider to use when logging in. */
-  provider: LoginProviderEnum;
-};
-
-/** The Headless Login Provider. */
-export type LoginProviderEnum =
-  /** The Facebook provider. */
-  | 'FACEBOOK'
-  /** The GitHub provider. */
-  | 'GITHUB'
-  /** The Google provider. */
-  | 'GOOGLE'
-  /** The Instagram provider. */
-  | 'INSTAGRAM'
-  /** The LinkedIn provider. */
-  | 'LINKEDIN'
-  /** The OAuth2 (Generic) provider. */
-  | 'OAUTH2_GENERIC'
-  /** The Password provider. */
-  | 'PASSWORD'
-  /** The Site Token provider. */
-  | 'SITETOKEN';
-
-/** Meta data. */
-export type MetaDataInput = {
-  /** Meta ID. */
-  id?: string | null | undefined;
-  /** Meta key. */
-  key: string;
-  /** Meta value. */
-  value: string;
-};
-
-/** The parsed response from the OAuth Provider. */
-export type OAuthProviderResponseInput = {
-  /** The authorization code returned from the OAuth provider. */
-  code: string;
-  /** The state returned from the OAuth provider. */
-  state?: string | null | undefined;
-};
-
-/** Order status enumeration */
-export type OrderStatusEnum =
-  /** Cancelled */
-  | 'CANCELLED'
-  /** Draft */
-  | 'CHECKOUT_DRAFT'
-  /** Completed */
-  | 'COMPLETED'
-  /** Failed */
-  | 'FAILED'
-  /** On hold */
-  | 'ON_HOLD'
-  /** Pending payment */
-  | 'PENDING'
-  /** Processing */
-  | 'PROCESSING'
-  /** Refunded */
-  | 'REFUNDED';
-
-/** The parsed response from the Password Provider. */
-export type PasswordProviderResponseInput = {
-  /** The password for the WordPress user. */
-  password: string;
-  /** The WordPress username to authenticate ass */
-  username: string;
-};
-
-/** Options for ordering the connection */
-export type ProductAttributeInput = {
-  attributeName: string;
-  attributeValue?: string | null | undefined;
-  id?: number | null | undefined;
-};
-
-/** Product attribute type enumeration */
-export type ProductAttributeTypesEnum =
-  /** A global product attribute */
-  | 'GLOBAL'
-  /** A local product attribute */
-  | 'LOCAL';
-
-/** Product type enumeration */
-export type ProductTypesEnum =
-  /** An external product */
-  | 'EXTERNAL'
-  /** A product group */
-  | 'GROUPED'
-  /** A simple product */
-  | 'SIMPLE'
-  /** A variable product */
-  | 'VARIABLE'
-  /** A product variation */
-  | 'VARIATION';
-
-/** Fields to order the Products connection by */
-export type ProductsOrderByEnum =
-  /** Order by publish date */
-  | 'DATE'
-  /** Preserve the ID order given in the IN array */
-  | 'IN'
-  /** Order by the menu order value */
-  | 'MENU_ORDER'
-  /** Order by last modified date */
-  | 'MODIFIED'
-  /** Order by name */
-  | 'NAME'
-  /** Preserve slug order given in the NAME_IN array */
-  | 'NAME_IN'
-  /** Order by date product sale starts */
-  | 'ON_SALE_FROM'
-  /** Order by date product sale ends */
-  | 'ON_SALE_TO'
-  /** Order by parent ID */
-  | 'PARENT'
-  /** Order by product popularity */
-  | 'POPULARITY'
-  /** Order by product's current price */
-  | 'PRICE'
-  /** Order by product average rating */
-  | 'RATING'
-  /** Order by product's regular price */
-  | 'REGULAR_PRICE'
-  /** Order by number of reviews on product */
-  | 'REVIEW_COUNT'
-  /** Order by product's sale price */
-  | 'SALE_PRICE'
-  /** Order by slug */
-  | 'SLUG'
-  /** Order by total sales of products sold */
-  | 'TOTAL_SALES';
-
-/** Input for the registerCustomer mutation. */
-export type RegisterCustomerInput = {
-  /** User's AOL IM account. */
-  aim?: string | null | undefined;
-  /** Set the current user to the newly registered customer. Avoid using in GraphiQL or contexts where a nonce is sent, as it will cause nonce verification to fail. */
-  authenticate?: boolean | null | undefined;
-  /** Customer billing information */
-  billing?: CustomerAddressInput | null | undefined;
-  /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: string | null | undefined;
-  /** A string containing content about the user. */
-  description?: string | null | undefined;
-  /** A string that will be shown on the site. Defaults to user's username. It is likely that you will want to change this, for both appearance and security through obscurity (that is if you dont use and delete the default admin user). */
-  displayName?: string | null | undefined;
-  /** A string containing the user's email address. */
-  email?: string | null | undefined;
-  /** The user's first name. */
-  firstName?: string | null | undefined;
-  /** User's Jabber account. */
-  jabber?: string | null | undefined;
-  /** The user's last name. */
-  lastName?: string | null | undefined;
-  /** User's locale. */
-  locale?: string | null | undefined;
-  /** Meta data. */
-  metaData?: Array<MetaDataInput | null | undefined> | null | undefined;
-  /** A string that contains a URL-friendly name for the user. The default is the user's username. */
-  nicename?: string | null | undefined;
-  /** The user's nickname, defaults to the user's username. */
-  nickname?: string | null | undefined;
-  /** A string that contains the plain text password for the user. */
-  password?: string | null | undefined;
-  /** The date the user registered. Format is Y-m-d H:i:s. */
-  registered?: string | null | undefined;
-  /** A string for whether to enable the rich editor or not. False if not empty. */
-  richEditing?: string | null | undefined;
-  /** Customer shipping address */
-  shipping?: CustomerAddressInput | null | undefined;
-  /** Customer shipping is identical to billing address */
-  shippingSameAsBilling?: boolean | null | undefined;
-  /** A string that contains the user's username. */
-  username?: string | null | undefined;
-  /** A string containing the user's URL for the user's web site. */
-  websiteUrl?: string | null | undefined;
-  /** User's Yahoo IM account. */
-  yim?: string | null | undefined;
-};
-
-/** Product stock status enumeration */
-export type StockStatusEnum =
-  | 'IN_STOCK'
-  | 'ON_BACKORDER'
-  | 'OUT_OF_STOCK';
-
-/** The Stripe Payment Method. Payment or Setup. */
-export type StripePaymentMethodEnum =
-  | 'PAYMENT'
-  | 'SETUP';
-
-/** Available classification systems for organizing content. Identifies the different taxonomy types that can be used for content categorization. */
-export type TaxonomyEnum =
-  /** Taxonomy enum category */
-  | 'CATEGORY'
-  /** Taxonomy enum graphql_document_group */
-  | 'GRAPHQLDOCUMENTGROUP'
-  /** Taxonomy enum pa_color */
-  | 'PACOLOR'
-  /** Taxonomy enum pa_range */
-  | 'PARANGE'
-  /** Taxonomy enum pa_size */
-  | 'PASIZE'
-  /** Taxonomy enum post_format */
-  | 'POSTFORMAT'
-  /** Taxonomy enum product_brand */
-  | 'PRODUCTBRAND'
-  /** Taxonomy enum product_cat */
-  | 'PRODUCTCATEGORY'
-  /** Taxonomy enum product_tag */
-  | 'PRODUCTTAG'
-  /** Taxonomy enum product_type */
-  | 'PRODUCTTYPE'
-  /** Taxonomy enum product_shipping_class */
-  | 'SHIPPINGCLASS'
-  /** Taxonomy enum post_tag */
-  | 'TAG'
-  /** Taxonomy enum product_visibility */
-  | 'VISIBLEPRODUCT';
-
-/** Input for the updateCustomer mutation. */
-export type UpdateCustomerInput = {
-  /** User's AOL IM account. */
-  aim?: string | null | undefined;
-  /** Customer billing information */
-  billing?: CustomerAddressInput | null | undefined;
-  /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
-  clientMutationId?: string | null | undefined;
-  /** A string containing content about the user. */
-  description?: string | null | undefined;
-  /** A string that will be shown on the site. Defaults to user's username. It is likely that you will want to change this, for both appearance and security through obscurity (that is if you dont use and delete the default admin user). */
-  displayName?: string | null | undefined;
-  /** A string containing the user's email address. */
-  email?: string | null | undefined;
-  /** The user's first name. */
-  firstName?: string | null | undefined;
-  /** The ID of the user */
-  id?: string | number | null | undefined;
-  /** Whether to save changes on the session or in the database */
-  isSession?: boolean | null | undefined;
-  /** User's Jabber account. */
-  jabber?: string | null | undefined;
-  /** The user's last name. */
-  lastName?: string | null | undefined;
-  /** User's locale. */
-  locale?: string | null | undefined;
-  /** Meta data. */
-  metaData?: Array<MetaDataInput | null | undefined> | null | undefined;
-  /** A string that contains a URL-friendly name for the user. The default is the user's username. */
-  nicename?: string | null | undefined;
-  /** The user's nickname, defaults to the user's username. */
-  nickname?: string | null | undefined;
-  /** A string that contains the plain text password for the user. */
-  password?: string | null | undefined;
-  /** The date the user registered. Format is Y-m-d H:i:s. */
-  registered?: string | null | undefined;
-  /** A string for whether to enable the rich editor or not. False if not empty. */
-  richEditing?: string | null | undefined;
-  /** An array of roles to be assigned to the user. */
-  roles?: Array<string | null | undefined> | null | undefined;
-  /** Customer shipping address */
-  shipping?: CustomerAddressInput | null | undefined;
-  /** Customer shipping is identical to billing address */
-  shippingSameAsBilling?: boolean | null | undefined;
-  /** A string containing the user's URL for the user's web site. */
-  websiteUrl?: string | null | undefined;
-  /** User's Yahoo IM account. */
-  yim?: string | null | undefined;
-};
-
 export type AddToCartMutationVariables = Exact<{
   input: AddToCartInput;
 }>;
 
 
-export type AddToCartMutation = { addToCart: { cart: { total: string | null, subtotal: string | null, totalTax: string | null, discountTotal: string | null, shippingTotal: string | null, needsShippingAddress: boolean | null, chosenShippingMethods: Array<string | null> | null, isEmpty: boolean | null, rawTotal: string | null, rawDiscountTotal: string | null, availableShippingMethods: Array<{ rates: Array<{ cost: string | null, id: string, label: string | null } | null> | null } | null> | null, appliedCoupons: Array<{ description: string | null, discountTax: string, discountAmount: string, code: string } | null> | null, contents: { itemCount: number | null, productCount: number | null, nodes: Array<{ quantity: number | null, key: string, product: { node:
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, externalUrl: string | null, buttonText: string | null, onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null }
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, averageRating: number | null, weight: string | null, length: string | null, width: string | null, height: string | null, reviewCount: number | null, virtual: boolean | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, weight: string | null, length: string | null, width: string | null, height: string | null, averageRating: number | null, reviewCount: number | null, totalSales: number | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, defaultAttributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null, variations: { nodes: Array<{ name: string | null, databaseId: number, price: string | null, regularPrice: string | null, salePrice: string | null, slug: string | null, stockQuantity: number | null, stockStatus: StockStatusEnum | null, hasAttributes: boolean | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, attributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null }> } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-             } | null, variation: { node: { name: string | null, slug: string | null, price: string | null, stockStatus: StockStatusEnum | null, regularPrice: string | null, salePrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null } } | null }> } | null } | null } | null };
+export type AddToCartMutation = { __typename?: 'RootMutation', addToCart?: { __typename?: 'AddToCartPayload', cart?: { __typename?: 'Cart', total?: string | null, subtotal?: string | null, totalTax?: string | null, discountTotal?: string | null, shippingTotal?: string | null, needsShippingAddress?: boolean | null, chosenShippingMethods?: Array<string | null> | null, isEmpty?: boolean | null, rawTotal?: string | null, rawDiscountTotal?: string | null, availableShippingMethods?: Array<{ __typename?: 'ShippingPackage', rates?: Array<{ __typename?: 'ShippingRate', cost?: string | null, id: string, label?: string | null } | null> | null } | null> | null, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', description?: string | null, discountTax: string, discountAmount: string, code: string } | null> | null, contents?: { __typename?: 'CartToCartItemConnection', itemCount?: number | null, productCount?: number | null, nodes: Array<{ __typename?: 'SimpleCartItem', quantity?: number | null, key: string, product?: { __typename?: 'CartItemToProductConnectionEdge', node:
+              | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, externalUrl?: string | null, buttonText?: string | null, onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+              | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null }
+              | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, averageRating?: number | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, reviewCount?: number | null, virtual?: boolean | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+              | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, averageRating?: number | null, reviewCount?: number | null, totalSales?: number | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, defaultAttributes?: { __typename?: 'ProductWithAttributesToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', name?: string | null, databaseId: number, price?: string | null, regularPrice?: string | null, salePrice?: string | null, slug?: string | null, stockQuantity?: number | null, stockStatus?: StockStatusEnum | null, hasAttributes?: boolean | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, attributes?: { __typename?: 'ProductVariationToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null }> } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+             } | null, variation?: { __typename?: 'CartItemToProductVariationConnectionEdge', node: { __typename?: 'SimpleProductVariation', name?: string | null, slug?: string | null, price?: string | null, stockStatus?: StockStatusEnum | null, regularPrice?: string | null, salePrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null } } | null }> } | null } | null } | null };
 
 export type ApplyCouponMutationVariables = Exact<{
-  code: string;
+  code: Scalars['String']['input'];
 }>;
 
 
-export type ApplyCouponMutation = { applyCoupon: { applied: { code: string, description: string | null, discountTax: string, discountAmount: string } | null, cart: { total: string | null, subtotal: string | null, totalTax: string | null, discountTotal: string | null, shippingTotal: string | null, needsShippingAddress: boolean | null, chosenShippingMethods: Array<string | null> | null, isEmpty: boolean | null, rawTotal: string | null, rawDiscountTotal: string | null, availableShippingMethods: Array<{ rates: Array<{ cost: string | null, id: string, label: string | null } | null> | null } | null> | null, appliedCoupons: Array<{ description: string | null, discountTax: string, discountAmount: string, code: string } | null> | null, contents: { itemCount: number | null, productCount: number | null, nodes: Array<{ quantity: number | null, key: string, product: { node:
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, externalUrl: string | null, buttonText: string | null, onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null }
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, averageRating: number | null, weight: string | null, length: string | null, width: string | null, height: string | null, reviewCount: number | null, virtual: boolean | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, weight: string | null, length: string | null, width: string | null, height: string | null, averageRating: number | null, reviewCount: number | null, totalSales: number | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, defaultAttributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null, variations: { nodes: Array<{ name: string | null, databaseId: number, price: string | null, regularPrice: string | null, salePrice: string | null, slug: string | null, stockQuantity: number | null, stockStatus: StockStatusEnum | null, hasAttributes: boolean | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, attributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null }> } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-             } | null, variation: { node: { name: string | null, slug: string | null, price: string | null, stockStatus: StockStatusEnum | null, regularPrice: string | null, salePrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null } } | null }> } | null } | null } | null };
+export type ApplyCouponMutation = { __typename?: 'RootMutation', applyCoupon?: { __typename?: 'ApplyCouponPayload', applied?: { __typename?: 'AppliedCoupon', code: string, description?: string | null, discountTax: string, discountAmount: string } | null, cart?: { __typename?: 'Cart', total?: string | null, subtotal?: string | null, totalTax?: string | null, discountTotal?: string | null, shippingTotal?: string | null, needsShippingAddress?: boolean | null, chosenShippingMethods?: Array<string | null> | null, isEmpty?: boolean | null, rawTotal?: string | null, rawDiscountTotal?: string | null, availableShippingMethods?: Array<{ __typename?: 'ShippingPackage', rates?: Array<{ __typename?: 'ShippingRate', cost?: string | null, id: string, label?: string | null } | null> | null } | null> | null, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', description?: string | null, discountTax: string, discountAmount: string, code: string } | null> | null, contents?: { __typename?: 'CartToCartItemConnection', itemCount?: number | null, productCount?: number | null, nodes: Array<{ __typename?: 'SimpleCartItem', quantity?: number | null, key: string, product?: { __typename?: 'CartItemToProductConnectionEdge', node:
+              | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, externalUrl?: string | null, buttonText?: string | null, onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+              | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null }
+              | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, averageRating?: number | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, reviewCount?: number | null, virtual?: boolean | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+              | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, averageRating?: number | null, reviewCount?: number | null, totalSales?: number | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, defaultAttributes?: { __typename?: 'ProductWithAttributesToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', name?: string | null, databaseId: number, price?: string | null, regularPrice?: string | null, salePrice?: string | null, slug?: string | null, stockQuantity?: number | null, stockStatus?: StockStatusEnum | null, hasAttributes?: boolean | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, attributes?: { __typename?: 'ProductVariationToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null }> } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+             } | null, variation?: { __typename?: 'CartItemToProductVariationConnectionEdge', node: { __typename?: 'SimpleProductVariation', name?: string | null, slug?: string | null, price?: string | null, stockStatus?: StockStatusEnum | null, regularPrice?: string | null, salePrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null } } | null }> } | null } | null } | null };
 
 export type ChangeShippingCountyMutationVariables = Exact<{
-  shippingState?: string | null | undefined;
+  shippingState?: InputMaybe<Scalars['String']['input']>;
   shippingCountry: CountriesEnum;
-  billingState?: string | null | undefined;
+  billingState?: InputMaybe<Scalars['String']['input']>;
   billingCountry: CountriesEnum;
 }>;
 
 
-export type ChangeShippingCountyMutation = { updateCustomer: { customer: { calculatedShipping: boolean | null, hasCalculatedShipping: boolean | null } | null } | null };
+export type ChangeShippingCountyMutation = { __typename?: 'RootMutation', updateCustomer?: { __typename?: 'UpdateCustomerPayload', customer?: { __typename?: 'Customer', calculatedShipping?: boolean | null, hasCalculatedShipping?: boolean | null } | null } | null };
 
 export type ChangeShippingMethodMutationVariables = Exact<{
-  shippingMethods?: Array<string | null | undefined> | string | null | undefined;
+  shippingMethods?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>> | InputMaybe<Scalars['String']['input']>>;
 }>;
 
 
-export type ChangeShippingMethodMutation = { updateShippingMethod: { cart: { total: string | null, subtotal: string | null, totalTax: string | null, discountTotal: string | null, shippingTotal: string | null, needsShippingAddress: boolean | null, chosenShippingMethods: Array<string | null> | null, isEmpty: boolean | null, rawTotal: string | null, rawDiscountTotal: string | null, availableShippingMethods: Array<{ rates: Array<{ cost: string | null, id: string, label: string | null } | null> | null } | null> | null, appliedCoupons: Array<{ description: string | null, discountTax: string, discountAmount: string, code: string } | null> | null, contents: { itemCount: number | null, productCount: number | null, nodes: Array<{ quantity: number | null, key: string, product: { node:
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, externalUrl: string | null, buttonText: string | null, onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null }
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, averageRating: number | null, weight: string | null, length: string | null, width: string | null, height: string | null, reviewCount: number | null, virtual: boolean | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, weight: string | null, length: string | null, width: string | null, height: string | null, averageRating: number | null, reviewCount: number | null, totalSales: number | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, defaultAttributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null, variations: { nodes: Array<{ name: string | null, databaseId: number, price: string | null, regularPrice: string | null, salePrice: string | null, slug: string | null, stockQuantity: number | null, stockStatus: StockStatusEnum | null, hasAttributes: boolean | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, attributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null }> } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-             } | null, variation: { node: { name: string | null, slug: string | null, price: string | null, stockStatus: StockStatusEnum | null, regularPrice: string | null, salePrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null } } | null }> } | null } | null } | null };
+export type ChangeShippingMethodMutation = { __typename?: 'RootMutation', updateShippingMethod?: { __typename?: 'UpdateShippingMethodPayload', cart?: { __typename?: 'Cart', total?: string | null, subtotal?: string | null, totalTax?: string | null, discountTotal?: string | null, shippingTotal?: string | null, needsShippingAddress?: boolean | null, chosenShippingMethods?: Array<string | null> | null, isEmpty?: boolean | null, rawTotal?: string | null, rawDiscountTotal?: string | null, availableShippingMethods?: Array<{ __typename?: 'ShippingPackage', rates?: Array<{ __typename?: 'ShippingRate', cost?: string | null, id: string, label?: string | null } | null> | null } | null> | null, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', description?: string | null, discountTax: string, discountAmount: string, code: string } | null> | null, contents?: { __typename?: 'CartToCartItemConnection', itemCount?: number | null, productCount?: number | null, nodes: Array<{ __typename?: 'SimpleCartItem', quantity?: number | null, key: string, product?: { __typename?: 'CartItemToProductConnectionEdge', node:
+              | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, externalUrl?: string | null, buttonText?: string | null, onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+              | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null }
+              | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, averageRating?: number | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, reviewCount?: number | null, virtual?: boolean | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+              | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, averageRating?: number | null, reviewCount?: number | null, totalSales?: number | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, defaultAttributes?: { __typename?: 'ProductWithAttributesToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', name?: string | null, databaseId: number, price?: string | null, regularPrice?: string | null, salePrice?: string | null, slug?: string | null, stockQuantity?: number | null, stockStatus?: StockStatusEnum | null, hasAttributes?: boolean | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, attributes?: { __typename?: 'ProductVariationToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null }> } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+             } | null, variation?: { __typename?: 'CartItemToProductVariationConnectionEdge', node: { __typename?: 'SimpleProductVariation', name?: string | null, slug?: string | null, price?: string | null, stockStatus?: StockStatusEnum | null, regularPrice?: string | null, salePrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null } } | null }> } | null } | null } | null };
 
 export type CheckoutMutationVariables = Exact<{
-  billing?: CustomerAddressInput | null | undefined;
-  metaData?: Array<MetaDataInput | null | undefined> | MetaDataInput | null | undefined;
-  paymentMethod?: string | null | undefined;
-  shipping?: CustomerAddressInput | null | undefined;
-  customerNote?: string | null | undefined;
-  shipToDifferentAddress?: boolean | null | undefined;
-  account?: CreateAccountInput | null | undefined;
-  transactionId?: string | null | undefined;
-  isPaid?: boolean | null | undefined;
-  shippingMethod?: Array<string | null | undefined> | string | null | undefined;
-  createdVia?: string | null | undefined;
+  billing?: InputMaybe<CustomerAddressInput>;
+  metaData?: InputMaybe<Array<InputMaybe<MetaDataInput>> | InputMaybe<MetaDataInput>>;
+  paymentMethod?: InputMaybe<Scalars['String']['input']>;
+  shipping?: InputMaybe<CustomerAddressInput>;
+  customerNote?: InputMaybe<Scalars['String']['input']>;
+  shipToDifferentAddress?: InputMaybe<Scalars['Boolean']['input']>;
+  account?: InputMaybe<CreateAccountInput>;
+  transactionId?: InputMaybe<Scalars['String']['input']>;
+  isPaid?: InputMaybe<Scalars['Boolean']['input']>;
+  shippingMethod?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>> | InputMaybe<Scalars['String']['input']>>;
+  createdVia?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
-export type CheckoutMutation = { checkout: { result: string | null, redirect: string | null, order: { needsPayment: boolean | null, needsProcessing: boolean | null, status: OrderStatusEnum | null, databaseId: number | null, orderKey: string | null, subtotal: string | null, total: string | null, totalTax: string | null, shippingTotal: string | null, paymentMethodTitle: string | null, paymentMethod: string | null, date: string | null, customer: { email: string | null } | null, lineItems: { nodes: Array<{ quantity: number | null, total: string | null, id: string, product: { node:
-              | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-              | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-              | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-              | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-             } | null, variation: { node: { name: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null } } | null }> } | null } | null } | null };
+export type CheckoutMutation = { __typename?: 'RootMutation', checkout?: { __typename?: 'CheckoutPayload', result?: string | null, redirect?: string | null, order?: { __typename?: 'Order', needsPayment?: boolean | null, needsProcessing?: boolean | null, status?: OrderStatusEnum | null, databaseId?: number | null, orderKey?: string | null, subtotal?: string | null, total?: string | null, totalTax?: string | null, shippingTotal?: string | null, paymentMethodTitle?: string | null, paymentMethod?: string | null, date?: string | null, customer?: { __typename?: 'Customer', email?: string | null } | null, lineItems?: { __typename?: 'OrderToLineItemConnection', nodes: Array<{ __typename?: 'LineItem', quantity?: number | null, total?: string | null, id: string, product?: { __typename?: 'LineItemToProductConnectionEdge', node:
+              | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+              | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+              | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+              | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+             } | null, variation?: { __typename?: 'LineItemToProductVariationConnectionEdge', node: { __typename?: 'SimpleProductVariation', name?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null } } | null }> } | null } | null } | null };
 
 export type EmptyCartMutationVariables = Exact<{ [key: string]: never; }>;
 
 
-export type EmptyCartMutation = { emptyCart: { cart: { total: string | null, subtotal: string | null, totalTax: string | null, discountTotal: string | null, shippingTotal: string | null, needsShippingAddress: boolean | null, chosenShippingMethods: Array<string | null> | null, isEmpty: boolean | null, rawTotal: string | null, rawDiscountTotal: string | null, availableShippingMethods: Array<{ rates: Array<{ cost: string | null, id: string, label: string | null } | null> | null } | null> | null, appliedCoupons: Array<{ description: string | null, discountTax: string, discountAmount: string, code: string } | null> | null, contents: { itemCount: number | null, productCount: number | null, nodes: Array<{ quantity: number | null, key: string, product: { node:
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, externalUrl: string | null, buttonText: string | null, onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null }
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, averageRating: number | null, weight: string | null, length: string | null, width: string | null, height: string | null, reviewCount: number | null, virtual: boolean | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, weight: string | null, length: string | null, width: string | null, height: string | null, averageRating: number | null, reviewCount: number | null, totalSales: number | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, defaultAttributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null, variations: { nodes: Array<{ name: string | null, databaseId: number, price: string | null, regularPrice: string | null, salePrice: string | null, slug: string | null, stockQuantity: number | null, stockStatus: StockStatusEnum | null, hasAttributes: boolean | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, attributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null }> } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-             } | null, variation: { node: { name: string | null, slug: string | null, price: string | null, stockStatus: StockStatusEnum | null, regularPrice: string | null, salePrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null } } | null }> } | null } | null } | null };
+export type EmptyCartMutation = { __typename?: 'RootMutation', emptyCart?: { __typename?: 'EmptyCartPayload', cart?: { __typename?: 'Cart', total?: string | null, subtotal?: string | null, totalTax?: string | null, discountTotal?: string | null, shippingTotal?: string | null, needsShippingAddress?: boolean | null, chosenShippingMethods?: Array<string | null> | null, isEmpty?: boolean | null, rawTotal?: string | null, rawDiscountTotal?: string | null, availableShippingMethods?: Array<{ __typename?: 'ShippingPackage', rates?: Array<{ __typename?: 'ShippingRate', cost?: string | null, id: string, label?: string | null } | null> | null } | null> | null, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', description?: string | null, discountTax: string, discountAmount: string, code: string } | null> | null, contents?: { __typename?: 'CartToCartItemConnection', itemCount?: number | null, productCount?: number | null, nodes: Array<{ __typename?: 'SimpleCartItem', quantity?: number | null, key: string, product?: { __typename?: 'CartItemToProductConnectionEdge', node:
+              | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, externalUrl?: string | null, buttonText?: string | null, onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+              | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null }
+              | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, averageRating?: number | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, reviewCount?: number | null, virtual?: boolean | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+              | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, averageRating?: number | null, reviewCount?: number | null, totalSales?: number | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, defaultAttributes?: { __typename?: 'ProductWithAttributesToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', name?: string | null, databaseId: number, price?: string | null, regularPrice?: string | null, salePrice?: string | null, slug?: string | null, stockQuantity?: number | null, stockStatus?: StockStatusEnum | null, hasAttributes?: boolean | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, attributes?: { __typename?: 'ProductVariationToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null }> } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+             } | null, variation?: { __typename?: 'CartItemToProductVariationConnectionEdge', node: { __typename?: 'SimpleProductVariation', name?: string | null, slug?: string | null, price?: string | null, stockStatus?: StockStatusEnum | null, regularPrice?: string | null, salePrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null } } | null }> } | null } | null } | null };
 
-export type CartFragment = { total: string | null, subtotal: string | null, totalTax: string | null, discountTotal: string | null, shippingTotal: string | null, needsShippingAddress: boolean | null, chosenShippingMethods: Array<string | null> | null, isEmpty: boolean | null, rawTotal: string | null, rawDiscountTotal: string | null, availableShippingMethods: Array<{ rates: Array<{ cost: string | null, id: string, label: string | null } | null> | null } | null> | null, appliedCoupons: Array<{ description: string | null, discountTax: string, discountAmount: string, code: string } | null> | null, contents: { itemCount: number | null, productCount: number | null, nodes: Array<{ quantity: number | null, key: string, product: { node:
-          | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, externalUrl: string | null, buttonText: string | null, onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-          | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null }
-          | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, averageRating: number | null, weight: string | null, length: string | null, width: string | null, height: string | null, reviewCount: number | null, virtual: boolean | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-          | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, weight: string | null, length: string | null, width: string | null, height: string | null, averageRating: number | null, reviewCount: number | null, totalSales: number | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, defaultAttributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null, variations: { nodes: Array<{ name: string | null, databaseId: number, price: string | null, regularPrice: string | null, salePrice: string | null, slug: string | null, stockQuantity: number | null, stockStatus: StockStatusEnum | null, hasAttributes: boolean | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, attributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null }> } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-         } | null, variation: { node: { name: string | null, slug: string | null, price: string | null, stockStatus: StockStatusEnum | null, regularPrice: string | null, salePrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null } } | null }> } | null };
+export type CartFragment = { __typename?: 'Cart', total?: string | null, subtotal?: string | null, totalTax?: string | null, discountTotal?: string | null, shippingTotal?: string | null, needsShippingAddress?: boolean | null, chosenShippingMethods?: Array<string | null> | null, isEmpty?: boolean | null, rawTotal?: string | null, rawDiscountTotal?: string | null, availableShippingMethods?: Array<{ __typename?: 'ShippingPackage', rates?: Array<{ __typename?: 'ShippingRate', cost?: string | null, id: string, label?: string | null } | null> | null } | null> | null, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', description?: string | null, discountTax: string, discountAmount: string, code: string } | null> | null, contents?: { __typename?: 'CartToCartItemConnection', itemCount?: number | null, productCount?: number | null, nodes: Array<{ __typename?: 'SimpleCartItem', quantity?: number | null, key: string, product?: { __typename?: 'CartItemToProductConnectionEdge', node:
+          | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, externalUrl?: string | null, buttonText?: string | null, onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+          | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null }
+          | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, averageRating?: number | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, reviewCount?: number | null, virtual?: boolean | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+          | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, averageRating?: number | null, reviewCount?: number | null, totalSales?: number | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, defaultAttributes?: { __typename?: 'ProductWithAttributesToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', name?: string | null, databaseId: number, price?: string | null, regularPrice?: string | null, salePrice?: string | null, slug?: string | null, stockQuantity?: number | null, stockStatus?: StockStatusEnum | null, hasAttributes?: boolean | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, attributes?: { __typename?: 'ProductVariationToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null }> } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+         } | null, variation?: { __typename?: 'CartItemToProductVariationConnectionEdge', node: { __typename?: 'SimpleProductVariation', name?: string | null, slug?: string | null, price?: string | null, stockStatus?: StockStatusEnum | null, regularPrice?: string | null, salePrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null } } | null }> } | null };
 
-export type CategoryImageFragment = { sourceUrl: string | null, altText: string | null, title: string | null };
+export type CategoryImageFragment = { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null };
 
-export type ProductCategoryFragment = { count: number | null, databaseId: number, id: string, name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null };
+export type ProductCategoryFragment = { __typename?: 'ProductCategory', count?: number | null, databaseId: number, id: string, name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null };
 
-export type CommentFragment = { content: string | null, id: string, date: string | null, author: { node:
-      | { name: string | null, avatar: { url: string | null } | null }
-      | { name: string | null, avatar: { url: string | null } | null }
+export type CommentFragment = { __typename?: 'Comment', content?: string | null, id: string, date?: string | null, author?: { __typename?: 'CommentToCommenterConnectionEdge', node:
+      | { __typename?: 'CommentAuthor', name?: string | null, avatar?: { __typename?: 'Avatar', url?: string | null } | null }
+      | { __typename?: 'User', name?: string | null, avatar?: { __typename?: 'Avatar', url?: string | null } | null }
      } | null };
 
-export type CustomerFragment = { lastName: string | null, email: string | null, firstName: string | null, username: string | null, databaseId: number | null, sessionToken: string | null, isPayingCustomer: boolean | null, date: string | null, billing: { address1: string | null, address2: string | null, city: string | null, country: CountriesEnum | null, email: string | null, firstName: string | null, lastName: string | null, phone: string | null, postcode: string | null, company: string | null, state: string | null } | null, shipping: { address1: string | null, address2: string | null, city: string | null, country: CountriesEnum | null, email: string | null, firstName: string | null, lastName: string | null, phone: string | null, postcode: string | null, company: string | null, state: string | null } | null };
+export type CustomerFragment = { __typename?: 'Customer', lastName?: string | null, email?: string | null, firstName?: string | null, username?: string | null, databaseId?: number | null, sessionToken?: string | null, isPayingCustomer?: boolean | null, date?: string | null, billing?: { __typename?: 'CustomerAddress', address1?: string | null, address2?: string | null, city?: string | null, country?: CountriesEnum | null, email?: string | null, firstName?: string | null, lastName?: string | null, phone?: string | null, postcode?: string | null, company?: string | null, state?: string | null } | null, shipping?: { __typename?: 'CustomerAddress', address1?: string | null, address2?: string | null, city?: string | null, country?: CountriesEnum | null, email?: string | null, firstName?: string | null, lastName?: string | null, phone?: string | null, postcode?: string | null, company?: string | null, state?: string | null } | null };
 
-export type AddressFragment = { address1: string | null, address2: string | null, city: string | null, country: CountriesEnum | null, email: string | null, firstName: string | null, lastName: string | null, phone: string | null, postcode: string | null, company: string | null, state: string | null };
+export type AddressFragment = { __typename?: 'CustomerAddress', address1?: string | null, address2?: string | null, city?: string | null, country?: CountriesEnum | null, email?: string | null, firstName?: string | null, lastName?: string | null, phone?: string | null, postcode?: string | null, company?: string | null, state?: string | null };
 
-export type DownloadableItemFragment = { id: string, name: string | null, url: string | null, accessExpires: string | null, downloadsRemaining: number | null, product:
-    | { name: string | null, slug: string | null }
-    | { name: string | null, slug: string | null }
-    | { name: string | null, slug: string | null }
-    | { name: string | null, slug: string | null }
-    | { name: string | null, slug: string | null }
+export type DownloadableItemFragment = { __typename?: 'DownloadableItem', id: string, name?: string | null, url?: string | null, accessExpires?: string | null, downloadsRemaining?: number | null, product?:
+    | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null }
+    | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null }
+    | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null }
+    | { __typename?: 'SimpleProductVariation', name?: string | null, slug?: string | null }
+    | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null }
    | null };
 
-export type ExternalProductFragment = { externalUrl: string | null, buttonText: string | null, onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null };
+export type ExternalProductFragment = { __typename?: 'ExternalProduct', externalUrl?: string | null, buttonText?: string | null, onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null };
 
-export type ImageFragment = { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number };
+export type ImageFragment = { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number };
 
-type LineItemProduct_ExternalProduct_Fragment = { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null };
+type LineItemProduct_ExternalProduct_Fragment = { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null };
 
-type LineItemProduct_GroupProduct_Fragment = { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null };
+type LineItemProduct_GroupProduct_Fragment = { __typename?: 'GroupProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null };
 
-type LineItemProduct_SimpleProduct_Fragment = { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null };
+type LineItemProduct_SimpleProduct_Fragment = { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null };
 
-type LineItemProduct_VariableProduct_Fragment = { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null };
+type LineItemProduct_VariableProduct_Fragment = { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null };
 
 export type LineItemProductFragment =
   | LineItemProduct_ExternalProduct_Fragment
@@ -32408,45 +31822,45 @@ export type LineItemProductFragment =
   | LineItemProduct_VariableProduct_Fragment
 ;
 
-export type LineItemVariationFragment = { name: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null };
+export type LineItemVariationFragment = { __typename?: 'SimpleProductVariation', name?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null };
 
-export type LineItemFragment = { quantity: number | null, total: string | null, id: string, product: { node:
-      | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-      | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-      | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-      | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-     } | null, variation: { node: { name: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null } } | null };
+export type LineItemFragment = { __typename?: 'LineItem', quantity?: number | null, total?: string | null, id: string, product?: { __typename?: 'LineItemToProductConnectionEdge', node:
+      | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+      | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+      | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+      | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+     } | null, variation?: { __typename?: 'LineItemToProductVariationConnectionEdge', node: { __typename?: 'SimpleProductVariation', name?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null } } | null };
 
-export type LoginClientFragment = { name: string | null, provider: LoginProviderEnum | null, isEnabled: boolean | null, authorizationUrl: string | null };
+export type LoginClientFragment = { __typename?: 'LoginClient', name?: string | null, provider?: LoginProviderEnum | null, isEnabled?: boolean | null, authorizationUrl?: string | null };
 
-export type OrderFragmentFragment = { orderNumber: string | null, date: string | null, status: OrderStatusEnum | null, needsPayment: boolean | null, needsProcessing: boolean | null, databaseId: number | null, orderKey: string | null, total: string | null, subtotal: string | null, discountTotal: string | null, totalTax: string | null, shippingTotal: string | null, paymentMethodTitle: string | null, paymentMethod: string | null, rawDiscountTotal: string | null, billing: { address1: string | null, address2: string | null, city: string | null, country: CountriesEnum | null, email: string | null, firstName: string | null, lastName: string | null, phone: string | null, postcode: string | null, company: string | null, state: string | null } | null, shipping: { address1: string | null, address2: string | null, city: string | null, country: CountriesEnum | null, email: string | null, firstName: string | null, lastName: string | null, phone: string | null, postcode: string | null, company: string | null, state: string | null } | null, customer: { lastName: string | null, email: string | null, firstName: string | null, username: string | null, databaseId: number | null, sessionToken: string | null, isPayingCustomer: boolean | null, date: string | null, downloadableItems: { nodes: Array<{ id: string, name: string | null, url: string | null, accessExpires: string | null, downloadsRemaining: number | null, product:
-          | { name: string | null, slug: string | null }
-          | { name: string | null, slug: string | null }
-          | { name: string | null, slug: string | null }
-          | { name: string | null, slug: string | null }
-          | { name: string | null, slug: string | null }
-         | null }> } | null, billing: { address1: string | null, address2: string | null, city: string | null, country: CountriesEnum | null, email: string | null, firstName: string | null, lastName: string | null, phone: string | null, postcode: string | null, company: string | null, state: string | null } | null, shipping: { address1: string | null, address2: string | null, city: string | null, country: CountriesEnum | null, email: string | null, firstName: string | null, lastName: string | null, phone: string | null, postcode: string | null, company: string | null, state: string | null } | null } | null, downloadableItems: { nodes: Array<{ id: string, name: string | null, url: string | null, accessExpires: string | null, downloadsRemaining: number | null, product:
-        | { name: string | null, slug: string | null }
-        | { name: string | null, slug: string | null }
-        | { name: string | null, slug: string | null }
-        | { name: string | null, slug: string | null }
-        | { name: string | null, slug: string | null }
-       | null }> } | null, lineItems: { nodes: Array<{ quantity: number | null, total: string | null, id: string, product: { node:
-          | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-          | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-          | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-          | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-         } | null, variation: { node: { name: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null } } | null }> } | null };
+export type OrderFragmentFragment = { __typename?: 'Order', orderNumber?: string | null, date?: string | null, status?: OrderStatusEnum | null, needsPayment?: boolean | null, needsProcessing?: boolean | null, databaseId?: number | null, orderKey?: string | null, total?: string | null, subtotal?: string | null, discountTotal?: string | null, totalTax?: string | null, shippingTotal?: string | null, paymentMethodTitle?: string | null, paymentMethod?: string | null, rawDiscountTotal?: string | null, billing?: { __typename?: 'CustomerAddress', address1?: string | null, address2?: string | null, city?: string | null, country?: CountriesEnum | null, email?: string | null, firstName?: string | null, lastName?: string | null, phone?: string | null, postcode?: string | null, company?: string | null, state?: string | null } | null, shipping?: { __typename?: 'CustomerAddress', address1?: string | null, address2?: string | null, city?: string | null, country?: CountriesEnum | null, email?: string | null, firstName?: string | null, lastName?: string | null, phone?: string | null, postcode?: string | null, company?: string | null, state?: string | null } | null, customer?: { __typename?: 'Customer', lastName?: string | null, email?: string | null, firstName?: string | null, username?: string | null, databaseId?: number | null, sessionToken?: string | null, isPayingCustomer?: boolean | null, date?: string | null, downloadableItems?: { __typename?: 'CustomerToDownloadableItemConnection', nodes: Array<{ __typename?: 'DownloadableItem', id: string, name?: string | null, url?: string | null, accessExpires?: string | null, downloadsRemaining?: number | null, product?:
+          | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null }
+          | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null }
+          | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null }
+          | { __typename?: 'SimpleProductVariation', name?: string | null, slug?: string | null }
+          | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null }
+         | null }> } | null, billing?: { __typename?: 'CustomerAddress', address1?: string | null, address2?: string | null, city?: string | null, country?: CountriesEnum | null, email?: string | null, firstName?: string | null, lastName?: string | null, phone?: string | null, postcode?: string | null, company?: string | null, state?: string | null } | null, shipping?: { __typename?: 'CustomerAddress', address1?: string | null, address2?: string | null, city?: string | null, country?: CountriesEnum | null, email?: string | null, firstName?: string | null, lastName?: string | null, phone?: string | null, postcode?: string | null, company?: string | null, state?: string | null } | null } | null, downloadableItems?: { __typename?: 'OrderToDownloadableItemConnection', nodes: Array<{ __typename?: 'DownloadableItem', id: string, name?: string | null, url?: string | null, accessExpires?: string | null, downloadsRemaining?: number | null, product?:
+        | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null }
+        | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null }
+        | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null }
+        | { __typename?: 'SimpleProductVariation', name?: string | null, slug?: string | null }
+        | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null }
+       | null }> } | null, lineItems?: { __typename?: 'OrderToLineItemConnection', nodes: Array<{ __typename?: 'LineItem', quantity?: number | null, total?: string | null, id: string, product?: { __typename?: 'LineItemToProductConnectionEdge', node:
+          | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+          | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+          | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+          | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+         } | null, variation?: { __typename?: 'LineItemToProductVariationConnectionEdge', node: { __typename?: 'SimpleProductVariation', name?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null } } | null }> } | null };
 
-export type PaymentGatewayFragment = { title: string | null, id: string, description: string | null, icon: string | null };
+export type PaymentGatewayFragment = { __typename?: 'PaymentGateway', title?: string | null, id: string, description?: string | null, icon?: string | null };
 
-type ProductCategories_ExternalProduct_Fragment = { productCategories: { nodes: Array<{ databaseId: number, slug: string | null, name: string | null, count: number | null }> } | null };
+type ProductCategories_ExternalProduct_Fragment = { __typename?: 'ExternalProduct', productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', databaseId: number, slug?: string | null, name?: string | null, count?: number | null }> } | null };
 
-type ProductCategories_GroupProduct_Fragment = { productCategories: { nodes: Array<{ databaseId: number, slug: string | null, name: string | null, count: number | null }> } | null };
+type ProductCategories_GroupProduct_Fragment = { __typename?: 'GroupProduct', productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', databaseId: number, slug?: string | null, name?: string | null, count?: number | null }> } | null };
 
-type ProductCategories_SimpleProduct_Fragment = { productCategories: { nodes: Array<{ databaseId: number, slug: string | null, name: string | null, count: number | null }> } | null };
+type ProductCategories_SimpleProduct_Fragment = { __typename?: 'SimpleProduct', productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', databaseId: number, slug?: string | null, name?: string | null, count?: number | null }> } | null };
 
-type ProductCategories_VariableProduct_Fragment = { productCategories: { nodes: Array<{ databaseId: number, slug: string | null, name: string | null, count: number | null }> } | null };
+type ProductCategories_VariableProduct_Fragment = { __typename?: 'VariableProduct', productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', databaseId: number, slug?: string | null, name?: string | null, count?: number | null }> } | null };
 
 export type ProductCategoriesFragment =
   | ProductCategories_ExternalProduct_Fragment
@@ -32455,15 +31869,15 @@ export type ProductCategoriesFragment =
   | ProductCategories_VariableProduct_Fragment
 ;
 
-type ProductPricing_ExternalProduct_Fragment = { onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null };
+type ProductPricing_ExternalProduct_Fragment = { __typename?: 'ExternalProduct', onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null };
 
-type ProductPricing_GroupProduct_Fragment = { onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null };
+type ProductPricing_GroupProduct_Fragment = { __typename?: 'GroupProduct', onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null };
 
-type ProductPricing_SimpleProduct_Fragment = { onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null };
+type ProductPricing_SimpleProduct_Fragment = { __typename?: 'SimpleProduct', onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null };
 
-type ProductPricing_SimpleProductVariation_Fragment = { onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null };
+type ProductPricing_SimpleProductVariation_Fragment = { __typename?: 'SimpleProductVariation', onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null };
 
-type ProductPricing_VariableProduct_Fragment = { onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null };
+type ProductPricing_VariableProduct_Fragment = { __typename?: 'VariableProduct', onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null };
 
 export type ProductPricingFragment =
   | ProductPricing_ExternalProduct_Fragment
@@ -32473,11 +31887,11 @@ export type ProductPricingFragment =
   | ProductPricing_VariableProduct_Fragment
 ;
 
-type ProductStock_SimpleProduct_Fragment = { stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null };
+type ProductStock_SimpleProduct_Fragment = { __typename?: 'SimpleProduct', stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null };
 
-type ProductStock_SimpleProductVariation_Fragment = { stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null };
+type ProductStock_SimpleProductVariation_Fragment = { __typename?: 'SimpleProductVariation', stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null };
 
-type ProductStock_VariableProduct_Fragment = { stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null };
+type ProductStock_VariableProduct_Fragment = { __typename?: 'VariableProduct', stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null };
 
 export type ProductStockFragment =
   | ProductStock_SimpleProduct_Fragment
@@ -32485,72 +31899,72 @@ export type ProductStockFragment =
   | ProductStock_VariableProduct_Fragment
 ;
 
-export type ProductVariationFragment = { name: string | null, databaseId: number, price: string | null, regularPrice: string | null, salePrice: string | null, slug: string | null, stockQuantity: number | null, stockStatus: StockStatusEnum | null, hasAttributes: boolean | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, attributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null };
+export type ProductVariationFragment = { __typename?: 'SimpleProductVariation', name?: string | null, databaseId: number, price?: string | null, regularPrice?: string | null, salePrice?: string | null, slug?: string | null, stockQuantity?: number | null, stockStatus?: StockStatusEnum | null, hasAttributes?: boolean | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, attributes?: { __typename?: 'ProductVariationToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null };
 
-export type SimpleProductFragment = { name: string | null, slug: string | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, averageRating: number | null, weight: string | null, length: string | null, width: string | null, height: string | null, reviewCount: number | null, virtual: boolean | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null };
+export type SimpleProductFragment = { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, averageRating?: number | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, reviewCount?: number | null, virtual?: boolean | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null };
 
-type Terms_ExternalProduct_Fragment = { terms: { nodes: Array<
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
+type Terms_ExternalProduct_Fragment = { __typename?: 'ExternalProduct', terms?: { __typename?: 'ProductToTermNodeConnection', nodes: Array<
+      | { __typename?: 'Category', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'GraphqlDocumentGroup', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'PaColor', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'PaRange', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'PaSize', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'PostFormat', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ProductBrand', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ProductCategory', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ProductTag', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ProductType', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ShippingClass', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'Tag', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'VisibleProduct', taxonomyName?: string | null, slug?: string | null }
     > } | null };
 
-type Terms_GroupProduct_Fragment = { terms: { nodes: Array<
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
+type Terms_GroupProduct_Fragment = { __typename?: 'GroupProduct', terms?: { __typename?: 'ProductToTermNodeConnection', nodes: Array<
+      | { __typename?: 'Category', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'GraphqlDocumentGroup', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'PaColor', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'PaRange', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'PaSize', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'PostFormat', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ProductBrand', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ProductCategory', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ProductTag', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ProductType', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ShippingClass', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'Tag', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'VisibleProduct', taxonomyName?: string | null, slug?: string | null }
     > } | null };
 
-type Terms_SimpleProduct_Fragment = { terms: { nodes: Array<
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
+type Terms_SimpleProduct_Fragment = { __typename?: 'SimpleProduct', terms?: { __typename?: 'ProductToTermNodeConnection', nodes: Array<
+      | { __typename?: 'Category', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'GraphqlDocumentGroup', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'PaColor', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'PaRange', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'PaSize', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'PostFormat', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ProductBrand', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ProductCategory', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ProductTag', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ProductType', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ShippingClass', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'Tag', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'VisibleProduct', taxonomyName?: string | null, slug?: string | null }
     > } | null };
 
-type Terms_VariableProduct_Fragment = { terms: { nodes: Array<
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
-      | { taxonomyName: string | null, slug: string | null }
+type Terms_VariableProduct_Fragment = { __typename?: 'VariableProduct', terms?: { __typename?: 'ProductToTermNodeConnection', nodes: Array<
+      | { __typename?: 'Category', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'GraphqlDocumentGroup', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'PaColor', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'PaRange', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'PaSize', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'PostFormat', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ProductBrand', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ProductCategory', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ProductTag', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ProductType', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'ShippingClass', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'Tag', taxonomyName?: string | null, slug?: string | null }
+      | { __typename?: 'VisibleProduct', taxonomyName?: string | null, slug?: string | null }
     > } | null };
 
 export type TermsFragment =
@@ -32560,357 +31974,361 @@ export type TermsFragment =
   | Terms_VariableProduct_Fragment
 ;
 
-export type VariableProductFragment = { name: string | null, slug: string | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, weight: string | null, length: string | null, width: string | null, height: string | null, averageRating: number | null, reviewCount: number | null, totalSales: number | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, defaultAttributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null, variations: { nodes: Array<{ name: string | null, databaseId: number, price: string | null, regularPrice: string | null, salePrice: string | null, slug: string | null, stockQuantity: number | null, stockStatus: StockStatusEnum | null, hasAttributes: boolean | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, attributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null }> } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null };
+export type VariableProductFragment = { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, averageRating?: number | null, reviewCount?: number | null, totalSales?: number | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, defaultAttributes?: { __typename?: 'ProductWithAttributesToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', name?: string | null, databaseId: number, price?: string | null, regularPrice?: string | null, salePrice?: string | null, slug?: string | null, stockQuantity?: number | null, stockStatus?: StockStatusEnum | null, hasAttributes?: boolean | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, attributes?: { __typename?: 'ProductVariationToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null }> } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null };
 
-export type VariationAttributeFragment = { name: string | null, attributeId: number | null, value: string | null, label: string | null };
+export type VariationAttributeFragment = { __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null };
 
-export type ViewerFragment = { lastName: string | null, email: string | null, databaseId: number, id: string, firstName: string | null, username: string | null, nicename: string | null, wooSessionToken: string | null, stripeCustomerId: string | null, savedPaymentMethods: Array<{ id: number | null, token: string | null, customerId: string | null, last4: string | null, expiryMonth: string | null, expiryYear: string | null, cardType: string | null, isDefault: boolean | null } | null> | null, avatar: { url: string | null } | null };
+export type ViewerFragment = { __typename?: 'User', lastName?: string | null, email?: string | null, databaseId: number, id: string, firstName?: string | null, username?: string | null, nicename?: string | null, wooSessionToken?: string | null, stripeCustomerId?: string | null, savedPaymentMethods?: Array<{ __typename?: 'SavedPaymentMethod', id?: number | null, token?: string | null, customerId?: string | null, last4?: string | null, expiryMonth?: string | null, expiryYear?: string | null, cardType?: string | null, isDefault?: boolean | null } | null> | null, avatar?: { __typename?: 'Avatar', url?: string | null } | null };
 
-export type ViewerSummaryFragment = { id: string, databaseId: number, firstName: string | null, lastName: string | null, username: string | null, nicename: string | null, email: string | null, wooSessionToken: string | null, avatar: { url: string | null } | null };
+export type ViewerSummaryFragment = { __typename?: 'User', id: string, databaseId: number, firstName?: string | null, lastName?: string | null, username?: string | null, nicename?: string | null, email?: string | null, wooSessionToken?: string | null, avatar?: { __typename?: 'Avatar', url?: string | null } | null };
 
 export type GetAllTermsQueryVariables = Exact<{
-  hideEmpty?: boolean | null | undefined;
-  taxonomies: Array<TaxonomyEnum | null | undefined> | TaxonomyEnum;
-  first?: number | null | undefined;
+  hideEmpty?: InputMaybe<Scalars['Boolean']['input']>;
+  taxonomies: Array<InputMaybe<TaxonomyEnum>> | InputMaybe<TaxonomyEnum>;
+  first?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 
-export type GetAllTermsQuery = { terms: { nodes: Array<
-      | { taxonomyName: string | null, name: string | null, slug: string | null, count: number | null }
-      | { taxonomyName: string | null, name: string | null, slug: string | null, count: number | null }
-      | { taxonomyName: string | null, name: string | null, slug: string | null, count: number | null }
-      | { taxonomyName: string | null, name: string | null, slug: string | null, count: number | null }
-      | { taxonomyName: string | null, name: string | null, slug: string | null, count: number | null }
-      | { taxonomyName: string | null, name: string | null, slug: string | null, count: number | null }
-      | { taxonomyName: string | null, name: string | null, slug: string | null, count: number | null }
-      | { taxonomyName: string | null, name: string | null, slug: string | null, count: number | null }
-      | { taxonomyName: string | null, name: string | null, slug: string | null, count: number | null }
-      | { taxonomyName: string | null, name: string | null, slug: string | null, count: number | null }
-      | { taxonomyName: string | null, name: string | null, slug: string | null, count: number | null }
-      | { taxonomyName: string | null, name: string | null, slug: string | null, count: number | null }
-      | { taxonomyName: string | null, name: string | null, slug: string | null, count: number | null }
+export type GetAllTermsQuery = { __typename?: 'RootQuery', terms?: { __typename?: 'RootQueryToTermNodeConnection', nodes: Array<
+      | { __typename?: 'Category', taxonomyName?: string | null, name?: string | null, slug?: string | null, count?: number | null }
+      | { __typename?: 'GraphqlDocumentGroup', taxonomyName?: string | null, name?: string | null, slug?: string | null, count?: number | null }
+      | { __typename?: 'PaColor', taxonomyName?: string | null, name?: string | null, slug?: string | null, count?: number | null }
+      | { __typename?: 'PaRange', taxonomyName?: string | null, name?: string | null, slug?: string | null, count?: number | null }
+      | { __typename?: 'PaSize', taxonomyName?: string | null, name?: string | null, slug?: string | null, count?: number | null }
+      | { __typename?: 'PostFormat', taxonomyName?: string | null, name?: string | null, slug?: string | null, count?: number | null }
+      | { __typename?: 'ProductBrand', taxonomyName?: string | null, name?: string | null, slug?: string | null, count?: number | null }
+      | { __typename?: 'ProductCategory', taxonomyName?: string | null, name?: string | null, slug?: string | null, count?: number | null }
+      | { __typename?: 'ProductTag', taxonomyName?: string | null, name?: string | null, slug?: string | null, count?: number | null }
+      | { __typename?: 'ProductType', taxonomyName?: string | null, name?: string | null, slug?: string | null, count?: number | null }
+      | { __typename?: 'ShippingClass', taxonomyName?: string | null, name?: string | null, slug?: string | null, count?: number | null }
+      | { __typename?: 'Tag', taxonomyName?: string | null, name?: string | null, slug?: string | null, count?: number | null }
+      | { __typename?: 'VisibleProduct', taxonomyName?: string | null, name?: string | null, slug?: string | null, count?: number | null }
     > } | null };
 
 export type GetAllowedCountriesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetAllowedCountriesQuery = { allowedCountries: Array<CountriesEnum | null> | null };
+export type GetAllowedCountriesQuery = { __typename?: 'RootQuery', allowedCountries?: Array<CountriesEnum | null> | null };
 
 export type GetCartQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetCartQuery = { cart: { total: string | null, subtotal: string | null, totalTax: string | null, discountTotal: string | null, shippingTotal: string | null, needsShippingAddress: boolean | null, chosenShippingMethods: Array<string | null> | null, isEmpty: boolean | null, rawTotal: string | null, rawDiscountTotal: string | null, availableShippingMethods: Array<{ rates: Array<{ cost: string | null, id: string, label: string | null } | null> | null } | null> | null, appliedCoupons: Array<{ description: string | null, discountTax: string, discountAmount: string, code: string } | null> | null, contents: { itemCount: number | null, productCount: number | null, nodes: Array<{ quantity: number | null, key: string, product: { node:
-            | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, externalUrl: string | null, buttonText: string | null, onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-            | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null }
-            | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, averageRating: number | null, weight: string | null, length: string | null, width: string | null, height: string | null, reviewCount: number | null, virtual: boolean | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-            | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, weight: string | null, length: string | null, width: string | null, height: string | null, averageRating: number | null, reviewCount: number | null, totalSales: number | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, defaultAttributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null, variations: { nodes: Array<{ name: string | null, databaseId: number, price: string | null, regularPrice: string | null, salePrice: string | null, slug: string | null, stockQuantity: number | null, stockStatus: StockStatusEnum | null, hasAttributes: boolean | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, attributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null }> } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-           } | null, variation: { node: { name: string | null, slug: string | null, price: string | null, stockStatus: StockStatusEnum | null, regularPrice: string | null, salePrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null } } | null }> } | null } | null, customer: { lastName: string | null, email: string | null, firstName: string | null, username: string | null, databaseId: number | null, sessionToken: string | null, isPayingCustomer: boolean | null, date: string | null, billing: { address1: string | null, address2: string | null, city: string | null, country: CountriesEnum | null, email: string | null, firstName: string | null, lastName: string | null, phone: string | null, postcode: string | null, company: string | null, state: string | null } | null, shipping: { address1: string | null, address2: string | null, city: string | null, country: CountriesEnum | null, email: string | null, firstName: string | null, lastName: string | null, phone: string | null, postcode: string | null, company: string | null, state: string | null } | null } | null, viewer: { lastName: string | null, email: string | null, databaseId: number, id: string, firstName: string | null, username: string | null, nicename: string | null, wooSessionToken: string | null, stripeCustomerId: string | null, savedPaymentMethods: Array<{ id: number | null, token: string | null, customerId: string | null, last4: string | null, expiryMonth: string | null, expiryYear: string | null, cardType: string | null, isDefault: boolean | null } | null> | null, avatar: { url: string | null } | null } | null, paymentGateways: { nodes: Array<{ title: string | null, id: string, description: string | null, icon: string | null }> } | null, loginClients: Array<{ name: string | null, provider: LoginProviderEnum | null, isEnabled: boolean | null, authorizationUrl: string | null } | null> | null };
+export type GetCartQuery = { __typename?: 'RootQuery', cart?: { __typename?: 'Cart', total?: string | null, subtotal?: string | null, totalTax?: string | null, discountTotal?: string | null, shippingTotal?: string | null, needsShippingAddress?: boolean | null, chosenShippingMethods?: Array<string | null> | null, isEmpty?: boolean | null, rawTotal?: string | null, rawDiscountTotal?: string | null, availableShippingMethods?: Array<{ __typename?: 'ShippingPackage', rates?: Array<{ __typename?: 'ShippingRate', cost?: string | null, id: string, label?: string | null } | null> | null } | null> | null, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', description?: string | null, discountTax: string, discountAmount: string, code: string } | null> | null, contents?: { __typename?: 'CartToCartItemConnection', itemCount?: number | null, productCount?: number | null, nodes: Array<{ __typename?: 'SimpleCartItem', quantity?: number | null, key: string, product?: { __typename?: 'CartItemToProductConnectionEdge', node:
+            | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, externalUrl?: string | null, buttonText?: string | null, onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+            | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null }
+            | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, averageRating?: number | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, reviewCount?: number | null, virtual?: boolean | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+            | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, averageRating?: number | null, reviewCount?: number | null, totalSales?: number | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, defaultAttributes?: { __typename?: 'ProductWithAttributesToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', name?: string | null, databaseId: number, price?: string | null, regularPrice?: string | null, salePrice?: string | null, slug?: string | null, stockQuantity?: number | null, stockStatus?: StockStatusEnum | null, hasAttributes?: boolean | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, attributes?: { __typename?: 'ProductVariationToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null }> } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+           } | null, variation?: { __typename?: 'CartItemToProductVariationConnectionEdge', node: { __typename?: 'SimpleProductVariation', name?: string | null, slug?: string | null, price?: string | null, stockStatus?: StockStatusEnum | null, regularPrice?: string | null, salePrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null } } | null }> } | null } | null, customer?: { __typename?: 'Customer', lastName?: string | null, email?: string | null, firstName?: string | null, username?: string | null, databaseId?: number | null, sessionToken?: string | null, isPayingCustomer?: boolean | null, date?: string | null, billing?: { __typename?: 'CustomerAddress', address1?: string | null, address2?: string | null, city?: string | null, country?: CountriesEnum | null, email?: string | null, firstName?: string | null, lastName?: string | null, phone?: string | null, postcode?: string | null, company?: string | null, state?: string | null } | null, shipping?: { __typename?: 'CustomerAddress', address1?: string | null, address2?: string | null, city?: string | null, country?: CountriesEnum | null, email?: string | null, firstName?: string | null, lastName?: string | null, phone?: string | null, postcode?: string | null, company?: string | null, state?: string | null } | null } | null, viewer?: { __typename?: 'User', lastName?: string | null, email?: string | null, databaseId: number, id: string, firstName?: string | null, username?: string | null, nicename?: string | null, wooSessionToken?: string | null, stripeCustomerId?: string | null, savedPaymentMethods?: Array<{ __typename?: 'SavedPaymentMethod', id?: number | null, token?: string | null, customerId?: string | null, last4?: string | null, expiryMonth?: string | null, expiryYear?: string | null, cardType?: string | null, isDefault?: boolean | null } | null> | null, avatar?: { __typename?: 'Avatar', url?: string | null } | null } | null, paymentGateways?: { __typename?: 'RootQueryToPaymentGatewayConnection', nodes: Array<{ __typename?: 'PaymentGateway', title?: string | null, id: string, description?: string | null, icon?: string | null }> } | null, loginClients?: Array<{ __typename?: 'LoginClient', name?: string | null, provider?: LoginProviderEnum | null, isEnabled?: boolean | null, authorizationUrl?: string | null } | null> | null };
 
 export type GetCartSummaryQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetCartSummaryQuery = { cart: { isEmpty: boolean | null, contents: { itemCount: number | null, productCount: number | null } | null } | null, viewer: { lastName: string | null, email: string | null, databaseId: number, id: string, firstName: string | null, username: string | null, nicename: string | null, wooSessionToken: string | null, stripeCustomerId: string | null, savedPaymentMethods: Array<{ id: number | null, token: string | null, customerId: string | null, last4: string | null, expiryMonth: string | null, expiryYear: string | null, cardType: string | null, isDefault: boolean | null } | null> | null, avatar: { url: string | null } | null } | null };
+export type GetCartSummaryQuery = { __typename?: 'RootQuery', cart?: { __typename?: 'Cart', isEmpty?: boolean | null, contents?: { __typename?: 'CartToCartItemConnection', itemCount?: number | null, productCount?: number | null } | null } | null, viewer?: { __typename?: 'User', lastName?: string | null, email?: string | null, databaseId: number, id: string, firstName?: string | null, username?: string | null, nicename?: string | null, wooSessionToken?: string | null, stripeCustomerId?: string | null, savedPaymentMethods?: Array<{ __typename?: 'SavedPaymentMethod', id?: number | null, token?: string | null, customerId?: string | null, last4?: string | null, expiryMonth?: string | null, expiryYear?: string | null, cardType?: string | null, isDefault?: boolean | null } | null> | null, avatar?: { __typename?: 'Avatar', url?: string | null } | null } | null };
 
 export type GetDownloadsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetDownloadsQuery = { customer: { downloadableItems: { nodes: Array<{ id: string, name: string | null, url: string | null, accessExpires: string | null, downloadsRemaining: number | null, product:
-          | { name: string | null, slug: string | null }
-          | { name: string | null, slug: string | null }
-          | { name: string | null, slug: string | null }
-          | { name: string | null, slug: string | null }
-          | { name: string | null, slug: string | null }
+export type GetDownloadsQuery = { __typename?: 'RootQuery', customer?: { __typename?: 'Customer', downloadableItems?: { __typename?: 'CustomerToDownloadableItemConnection', nodes: Array<{ __typename?: 'DownloadableItem', id: string, name?: string | null, url?: string | null, accessExpires?: string | null, downloadsRemaining?: number | null, product?:
+          | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null }
+          | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null }
+          | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null }
+          | { __typename?: 'SimpleProductVariation', name?: string | null, slug?: string | null }
+          | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null }
          | null }> } | null } | null };
 
 export type GetOrderQueryVariables = Exact<{
-  id: string;
+  id: Scalars['String']['input'];
 }>;
 
 
-export type GetOrderQuery = { customer: { orders: { nodes: Array<{ orderNumber: string | null, date: string | null, status: OrderStatusEnum | null, needsPayment: boolean | null, needsProcessing: boolean | null, databaseId: number | null, orderKey: string | null, total: string | null, subtotal: string | null, discountTotal: string | null, totalTax: string | null, shippingTotal: string | null, paymentMethodTitle: string | null, paymentMethod: string | null, rawDiscountTotal: string | null, billing: { address1: string | null, address2: string | null, city: string | null, country: CountriesEnum | null, email: string | null, firstName: string | null, lastName: string | null, phone: string | null, postcode: string | null, company: string | null, state: string | null } | null, shipping: { address1: string | null, address2: string | null, city: string | null, country: CountriesEnum | null, email: string | null, firstName: string | null, lastName: string | null, phone: string | null, postcode: string | null, company: string | null, state: string | null } | null, customer: { lastName: string | null, email: string | null, firstName: string | null, username: string | null, databaseId: number | null, sessionToken: string | null, isPayingCustomer: boolean | null, date: string | null, downloadableItems: { nodes: Array<{ id: string, name: string | null, url: string | null, accessExpires: string | null, downloadsRemaining: number | null, product:
-                | { name: string | null, slug: string | null }
-                | { name: string | null, slug: string | null }
-                | { name: string | null, slug: string | null }
-                | { name: string | null, slug: string | null }
-                | { name: string | null, slug: string | null }
-               | null }> } | null, billing: { address1: string | null, address2: string | null, city: string | null, country: CountriesEnum | null, email: string | null, firstName: string | null, lastName: string | null, phone: string | null, postcode: string | null, company: string | null, state: string | null } | null, shipping: { address1: string | null, address2: string | null, city: string | null, country: CountriesEnum | null, email: string | null, firstName: string | null, lastName: string | null, phone: string | null, postcode: string | null, company: string | null, state: string | null } | null } | null, downloadableItems: { nodes: Array<{ id: string, name: string | null, url: string | null, accessExpires: string | null, downloadsRemaining: number | null, product:
-              | { name: string | null, slug: string | null }
-              | { name: string | null, slug: string | null }
-              | { name: string | null, slug: string | null }
-              | { name: string | null, slug: string | null }
-              | { name: string | null, slug: string | null }
-             | null }> } | null, lineItems: { nodes: Array<{ quantity: number | null, total: string | null, id: string, product: { node:
-                | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-                | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-                | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-                | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-               } | null, variation: { node: { name: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null } } | null }> } | null }> } | null } | null };
+export type GetOrderQuery = { __typename?: 'RootQuery', customer?: { __typename?: 'Customer', orders?: { __typename?: 'CustomerToOrderConnection', nodes: Array<{ __typename?: 'Order', orderNumber?: string | null, date?: string | null, status?: OrderStatusEnum | null, needsPayment?: boolean | null, needsProcessing?: boolean | null, databaseId?: number | null, orderKey?: string | null, total?: string | null, subtotal?: string | null, discountTotal?: string | null, totalTax?: string | null, shippingTotal?: string | null, paymentMethodTitle?: string | null, paymentMethod?: string | null, rawDiscountTotal?: string | null, billing?: { __typename?: 'CustomerAddress', address1?: string | null, address2?: string | null, city?: string | null, country?: CountriesEnum | null, email?: string | null, firstName?: string | null, lastName?: string | null, phone?: string | null, postcode?: string | null, company?: string | null, state?: string | null } | null, shipping?: { __typename?: 'CustomerAddress', address1?: string | null, address2?: string | null, city?: string | null, country?: CountriesEnum | null, email?: string | null, firstName?: string | null, lastName?: string | null, phone?: string | null, postcode?: string | null, company?: string | null, state?: string | null } | null, customer?: { __typename?: 'Customer', lastName?: string | null, email?: string | null, firstName?: string | null, username?: string | null, databaseId?: number | null, sessionToken?: string | null, isPayingCustomer?: boolean | null, date?: string | null, downloadableItems?: { __typename?: 'CustomerToDownloadableItemConnection', nodes: Array<{ __typename?: 'DownloadableItem', id: string, name?: string | null, url?: string | null, accessExpires?: string | null, downloadsRemaining?: number | null, product?:
+                | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null }
+                | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null }
+                | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null }
+                | { __typename?: 'SimpleProductVariation', name?: string | null, slug?: string | null }
+                | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null }
+               | null }> } | null, billing?: { __typename?: 'CustomerAddress', address1?: string | null, address2?: string | null, city?: string | null, country?: CountriesEnum | null, email?: string | null, firstName?: string | null, lastName?: string | null, phone?: string | null, postcode?: string | null, company?: string | null, state?: string | null } | null, shipping?: { __typename?: 'CustomerAddress', address1?: string | null, address2?: string | null, city?: string | null, country?: CountriesEnum | null, email?: string | null, firstName?: string | null, lastName?: string | null, phone?: string | null, postcode?: string | null, company?: string | null, state?: string | null } | null } | null, downloadableItems?: { __typename?: 'OrderToDownloadableItemConnection', nodes: Array<{ __typename?: 'DownloadableItem', id: string, name?: string | null, url?: string | null, accessExpires?: string | null, downloadsRemaining?: number | null, product?:
+              | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null }
+              | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null }
+              | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null }
+              | { __typename?: 'SimpleProductVariation', name?: string | null, slug?: string | null }
+              | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null }
+             | null }> } | null, lineItems?: { __typename?: 'OrderToLineItemConnection', nodes: Array<{ __typename?: 'LineItem', quantity?: number | null, total?: string | null, id: string, product?: { __typename?: 'LineItemToProductConnectionEdge', node:
+                | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+                | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+                | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+                | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+               } | null, variation?: { __typename?: 'LineItemToProductVariationConnectionEdge', node: { __typename?: 'SimpleProductVariation', name?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null } } | null }> } | null }> } | null } | null };
 
 export type GetOrdersQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetOrdersQuery = { customer: { orders: { nodes: Array<{ orderNumber: string | null, date: string | null, status: OrderStatusEnum | null, needsPayment: boolean | null, needsProcessing: boolean | null, databaseId: number | null, orderKey: string | null, total: string | null, subtotal: string | null, discountTotal: string | null, totalTax: string | null, shippingTotal: string | null, paymentMethodTitle: string | null, paymentMethod: string | null, rawDiscountTotal: string | null, billing: { address1: string | null, address2: string | null, city: string | null, country: CountriesEnum | null, email: string | null, firstName: string | null, lastName: string | null, phone: string | null, postcode: string | null, company: string | null, state: string | null } | null, shipping: { address1: string | null, address2: string | null, city: string | null, country: CountriesEnum | null, email: string | null, firstName: string | null, lastName: string | null, phone: string | null, postcode: string | null, company: string | null, state: string | null } | null, customer: { lastName: string | null, email: string | null, firstName: string | null, username: string | null, databaseId: number | null, sessionToken: string | null, isPayingCustomer: boolean | null, date: string | null, downloadableItems: { nodes: Array<{ id: string, name: string | null, url: string | null, accessExpires: string | null, downloadsRemaining: number | null, product:
-                | { name: string | null, slug: string | null }
-                | { name: string | null, slug: string | null }
-                | { name: string | null, slug: string | null }
-                | { name: string | null, slug: string | null }
-                | { name: string | null, slug: string | null }
-               | null }> } | null, billing: { address1: string | null, address2: string | null, city: string | null, country: CountriesEnum | null, email: string | null, firstName: string | null, lastName: string | null, phone: string | null, postcode: string | null, company: string | null, state: string | null } | null, shipping: { address1: string | null, address2: string | null, city: string | null, country: CountriesEnum | null, email: string | null, firstName: string | null, lastName: string | null, phone: string | null, postcode: string | null, company: string | null, state: string | null } | null } | null, downloadableItems: { nodes: Array<{ id: string, name: string | null, url: string | null, accessExpires: string | null, downloadsRemaining: number | null, product:
-              | { name: string | null, slug: string | null }
-              | { name: string | null, slug: string | null }
-              | { name: string | null, slug: string | null }
-              | { name: string | null, slug: string | null }
-              | { name: string | null, slug: string | null }
-             | null }> } | null, lineItems: { nodes: Array<{ quantity: number | null, total: string | null, id: string, product: { node:
-                | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-                | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-                | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-                | { name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }
-               } | null, variation: { node: { name: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null } } | null }> } | null }> } | null } | null };
+export type GetOrdersQuery = { __typename?: 'RootQuery', customer?: { __typename?: 'Customer', orders?: { __typename?: 'CustomerToOrderConnection', nodes: Array<{ __typename?: 'Order', orderNumber?: string | null, date?: string | null, status?: OrderStatusEnum | null, needsPayment?: boolean | null, needsProcessing?: boolean | null, databaseId?: number | null, orderKey?: string | null, total?: string | null, subtotal?: string | null, discountTotal?: string | null, totalTax?: string | null, shippingTotal?: string | null, paymentMethodTitle?: string | null, paymentMethod?: string | null, rawDiscountTotal?: string | null, billing?: { __typename?: 'CustomerAddress', address1?: string | null, address2?: string | null, city?: string | null, country?: CountriesEnum | null, email?: string | null, firstName?: string | null, lastName?: string | null, phone?: string | null, postcode?: string | null, company?: string | null, state?: string | null } | null, shipping?: { __typename?: 'CustomerAddress', address1?: string | null, address2?: string | null, city?: string | null, country?: CountriesEnum | null, email?: string | null, firstName?: string | null, lastName?: string | null, phone?: string | null, postcode?: string | null, company?: string | null, state?: string | null } | null, customer?: { __typename?: 'Customer', lastName?: string | null, email?: string | null, firstName?: string | null, username?: string | null, databaseId?: number | null, sessionToken?: string | null, isPayingCustomer?: boolean | null, date?: string | null, downloadableItems?: { __typename?: 'CustomerToDownloadableItemConnection', nodes: Array<{ __typename?: 'DownloadableItem', id: string, name?: string | null, url?: string | null, accessExpires?: string | null, downloadsRemaining?: number | null, product?:
+                | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null }
+                | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null }
+                | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null }
+                | { __typename?: 'SimpleProductVariation', name?: string | null, slug?: string | null }
+                | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null }
+               | null }> } | null, billing?: { __typename?: 'CustomerAddress', address1?: string | null, address2?: string | null, city?: string | null, country?: CountriesEnum | null, email?: string | null, firstName?: string | null, lastName?: string | null, phone?: string | null, postcode?: string | null, company?: string | null, state?: string | null } | null, shipping?: { __typename?: 'CustomerAddress', address1?: string | null, address2?: string | null, city?: string | null, country?: CountriesEnum | null, email?: string | null, firstName?: string | null, lastName?: string | null, phone?: string | null, postcode?: string | null, company?: string | null, state?: string | null } | null } | null, downloadableItems?: { __typename?: 'OrderToDownloadableItemConnection', nodes: Array<{ __typename?: 'DownloadableItem', id: string, name?: string | null, url?: string | null, accessExpires?: string | null, downloadsRemaining?: number | null, product?:
+              | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null }
+              | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null }
+              | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null }
+              | { __typename?: 'SimpleProductVariation', name?: string | null, slug?: string | null }
+              | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null }
+             | null }> } | null, lineItems?: { __typename?: 'OrderToLineItemConnection', nodes: Array<{ __typename?: 'LineItem', quantity?: number | null, total?: string | null, id: string, product?: { __typename?: 'LineItemToProductConnectionEdge', node:
+                | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+                | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+                | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+                | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }
+               } | null, variation?: { __typename?: 'LineItemToProductVariationConnectionEdge', node: { __typename?: 'SimpleProductVariation', name?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null } } | null }> } | null }> } | null } | null };
 
 export type GetProductQueryVariables = Exact<{
-  slug: string | number;
-  frontEndUrl?: string | null | undefined;
+  slug: Scalars['ID']['input'];
+  frontEndUrl?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
-export type GetProductQuery = { product:
-    | { name: string | null, type: ProductTypesEnum | null, databaseId: number, id: string, fullYoastHead: string | null, slug: string | null, sku: string | null, description: string | null, shortDescription: string | null, externalUrl: string | null, buttonText: string | null, onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawDescription: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, metaData: Array<{ id: string | null, key: string, value: string | null } | null> | null, related: { nodes: Array<
-          | { externalUrl: string | null, buttonText: string | null, onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-          | { name: string | null, slug: string | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, averageRating: number | null, weight: string | null, length: string | null, width: string | null, height: string | null, reviewCount: number | null, virtual: boolean | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-          | { name: string | null, slug: string | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, weight: string | null, length: string | null, width: string | null, height: string | null, averageRating: number | null, reviewCount: number | null, totalSales: number | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, defaultAttributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null, variations: { nodes: Array<{ name: string | null, databaseId: number, price: string | null, regularPrice: string | null, salePrice: string | null, slug: string | null, stockQuantity: number | null, stockStatus: StockStatusEnum | null, hasAttributes: boolean | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, attributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null }> } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-          | Record<PropertyKey, never>
-        > } | null, reviews: { averageRating: number | null, edges: Array<{ rating: number | null, node: { content: string | null, id: string, date: string | null, author: { node:
-                | { name: string | null, avatar: { url: string | null } | null }
-                | { name: string | null, avatar: { url: string | null } | null }
-               } | null } }> } | null, attributes: { nodes: Array<
-          | { variation: boolean | null, name: string | null, id: string, options: Array<string | null> | null, label: string | null, scope: ProductAttributeTypesEnum, terms: { nodes: Array<
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
+export type GetProductQuery = { __typename?: 'RootQuery', product?:
+    | { __typename?: 'ExternalProduct', name?: string | null, type?: ProductTypesEnum | null, databaseId: number, id: string, fullYoastHead?: string | null, slug?: string | null, sku?: string | null, description?: string | null, shortDescription?: string | null, externalUrl?: string | null, buttonText?: string | null, onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawDescription?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, metaData?: Array<{ __typename?: 'MetaData', id?: string | null, key: string, value?: string | null } | null> | null, related?: { __typename?: 'ProductToProductUnionConnection', nodes: Array<
+          | { __typename?: 'ExternalProduct', externalUrl?: string | null, buttonText?: string | null, onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+          | { __typename?: 'GroupProduct' }
+          | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, averageRating?: number | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, reviewCount?: number | null, virtual?: boolean | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+          | { __typename?: 'SimpleProductVariation' }
+          | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, averageRating?: number | null, reviewCount?: number | null, totalSales?: number | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, defaultAttributes?: { __typename?: 'ProductWithAttributesToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', name?: string | null, databaseId: number, price?: string | null, regularPrice?: string | null, salePrice?: string | null, slug?: string | null, stockQuantity?: number | null, stockStatus?: StockStatusEnum | null, hasAttributes?: boolean | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, attributes?: { __typename?: 'ProductVariationToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null }> } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+        > } | null, reviews?: { __typename?: 'ProductToCommentConnection', averageRating?: number | null, edges: Array<{ __typename?: 'ProductToCommentConnectionEdge', rating?: number | null, node: { __typename?: 'Comment', content?: string | null, id: string, date?: string | null, author?: { __typename?: 'CommentToCommenterConnectionEdge', node:
+                | { __typename?: 'CommentAuthor', name?: string | null, avatar?: { __typename?: 'Avatar', url?: string | null } | null }
+                | { __typename?: 'User', name?: string | null, avatar?: { __typename?: 'Avatar', url?: string | null } | null }
+               } | null } }> } | null, attributes?: { __typename?: 'ProductWithAttributesToProductAttributeConnection', nodes: Array<
+          | { __typename?: 'GlobalProductAttribute', variation?: boolean | null, name?: string | null, id: string, options?: Array<string | null> | null, label?: string | null, scope: ProductAttributeTypesEnum, terms?: { __typename?: 'GlobalProductAttributeToTermNodeConnection', nodes: Array<
+                | { __typename?: 'Category', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'GraphqlDocumentGroup', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'PaColor', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'PaRange', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'PaSize', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'PostFormat', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ProductBrand', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ProductCategory', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ProductTag', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ProductType', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ShippingClass', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'Tag', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'VisibleProduct', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
               > } | null }
-          | { variation: boolean | null, name: string | null, id: string, options: Array<string | null> | null, label: string | null, scope: ProductAttributeTypesEnum }
-        > } | null, productCategories: { nodes: Array<{ databaseId: number, slug: string | null, name: string | null, count: number | null }> } | null, terms: { nodes: Array<
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-        > } | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-    | { name: string | null, type: ProductTypesEnum | null, databaseId: number, id: string, fullYoastHead: string | null, slug: string | null, sku: string | null, description: string | null, shortDescription: string | null, rawDescription: string | null, metaData: Array<{ id: string | null, key: string, value: string | null } | null> | null, related: { nodes: Array<
-          | { externalUrl: string | null, buttonText: string | null, onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-          | { name: string | null, slug: string | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, averageRating: number | null, weight: string | null, length: string | null, width: string | null, height: string | null, reviewCount: number | null, virtual: boolean | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-          | { name: string | null, slug: string | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, weight: string | null, length: string | null, width: string | null, height: string | null, averageRating: number | null, reviewCount: number | null, totalSales: number | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, defaultAttributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null, variations: { nodes: Array<{ name: string | null, databaseId: number, price: string | null, regularPrice: string | null, salePrice: string | null, slug: string | null, stockQuantity: number | null, stockStatus: StockStatusEnum | null, hasAttributes: boolean | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, attributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null }> } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-          | Record<PropertyKey, never>
-        > } | null, reviews: { averageRating: number | null, edges: Array<{ rating: number | null, node: { content: string | null, id: string, date: string | null, author: { node:
-                | { name: string | null, avatar: { url: string | null } | null }
-                | { name: string | null, avatar: { url: string | null } | null }
-               } | null } }> } | null, attributes: { nodes: Array<
-          | { variation: boolean | null, name: string | null, id: string, options: Array<string | null> | null, label: string | null, scope: ProductAttributeTypesEnum, terms: { nodes: Array<
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
+          | { __typename?: 'LocalProductAttribute', variation?: boolean | null, name?: string | null, id: string, options?: Array<string | null> | null, label?: string | null, scope: ProductAttributeTypesEnum }
+        > } | null, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', databaseId: number, slug?: string | null, name?: string | null, count?: number | null }> } | null, terms?: { __typename?: 'ProductToTermNodeConnection', nodes: Array<
+          | { __typename?: 'Category', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'GraphqlDocumentGroup', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'PaColor', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'PaRange', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'PaSize', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'PostFormat', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ProductBrand', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ProductCategory', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ProductTag', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ProductType', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ShippingClass', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'Tag', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'VisibleProduct', taxonomyName?: string | null, slug?: string | null }
+        > } | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+    | { __typename?: 'GroupProduct', name?: string | null, type?: ProductTypesEnum | null, databaseId: number, id: string, fullYoastHead?: string | null, slug?: string | null, sku?: string | null, description?: string | null, shortDescription?: string | null, rawDescription?: string | null, metaData?: Array<{ __typename?: 'MetaData', id?: string | null, key: string, value?: string | null } | null> | null, related?: { __typename?: 'ProductToProductUnionConnection', nodes: Array<
+          | { __typename?: 'ExternalProduct', externalUrl?: string | null, buttonText?: string | null, onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+          | { __typename?: 'GroupProduct' }
+          | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, averageRating?: number | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, reviewCount?: number | null, virtual?: boolean | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+          | { __typename?: 'SimpleProductVariation' }
+          | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, averageRating?: number | null, reviewCount?: number | null, totalSales?: number | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, defaultAttributes?: { __typename?: 'ProductWithAttributesToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', name?: string | null, databaseId: number, price?: string | null, regularPrice?: string | null, salePrice?: string | null, slug?: string | null, stockQuantity?: number | null, stockStatus?: StockStatusEnum | null, hasAttributes?: boolean | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, attributes?: { __typename?: 'ProductVariationToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null }> } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+        > } | null, reviews?: { __typename?: 'ProductToCommentConnection', averageRating?: number | null, edges: Array<{ __typename?: 'ProductToCommentConnectionEdge', rating?: number | null, node: { __typename?: 'Comment', content?: string | null, id: string, date?: string | null, author?: { __typename?: 'CommentToCommenterConnectionEdge', node:
+                | { __typename?: 'CommentAuthor', name?: string | null, avatar?: { __typename?: 'Avatar', url?: string | null } | null }
+                | { __typename?: 'User', name?: string | null, avatar?: { __typename?: 'Avatar', url?: string | null } | null }
+               } | null } }> } | null, attributes?: { __typename?: 'ProductWithAttributesToProductAttributeConnection', nodes: Array<
+          | { __typename?: 'GlobalProductAttribute', variation?: boolean | null, name?: string | null, id: string, options?: Array<string | null> | null, label?: string | null, scope: ProductAttributeTypesEnum, terms?: { __typename?: 'GlobalProductAttributeToTermNodeConnection', nodes: Array<
+                | { __typename?: 'Category', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'GraphqlDocumentGroup', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'PaColor', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'PaRange', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'PaSize', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'PostFormat', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ProductBrand', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ProductCategory', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ProductTag', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ProductType', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ShippingClass', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'Tag', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'VisibleProduct', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
               > } | null }
-          | { variation: boolean | null, name: string | null, id: string, options: Array<string | null> | null, label: string | null, scope: ProductAttributeTypesEnum }
-        > } | null, productCategories: { nodes: Array<{ databaseId: number, slug: string | null, name: string | null, count: number | null }> } | null, terms: { nodes: Array<
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
+          | { __typename?: 'LocalProductAttribute', variation?: boolean | null, name?: string | null, id: string, options?: Array<string | null> | null, label?: string | null, scope: ProductAttributeTypesEnum }
+        > } | null, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', databaseId: number, slug?: string | null, name?: string | null, count?: number | null }> } | null, terms?: { __typename?: 'ProductToTermNodeConnection', nodes: Array<
+          | { __typename?: 'Category', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'GraphqlDocumentGroup', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'PaColor', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'PaRange', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'PaSize', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'PostFormat', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ProductBrand', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ProductCategory', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ProductTag', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ProductType', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ShippingClass', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'Tag', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'VisibleProduct', taxonomyName?: string | null, slug?: string | null }
         > } | null }
-    | { name: string | null, type: ProductTypesEnum | null, databaseId: number, id: string, fullYoastHead: string | null, slug: string | null, sku: string | null, description: string | null, shortDescription: string | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, averageRating: number | null, weight: string | null, length: string | null, width: string | null, height: string | null, reviewCount: number | null, virtual: boolean | null, rawDescription: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, metaData: Array<{ id: string | null, key: string, value: string | null } | null> | null, related: { nodes: Array<
-          | { externalUrl: string | null, buttonText: string | null, onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-          | { name: string | null, slug: string | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, averageRating: number | null, weight: string | null, length: string | null, width: string | null, height: string | null, reviewCount: number | null, virtual: boolean | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-          | { name: string | null, slug: string | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, weight: string | null, length: string | null, width: string | null, height: string | null, averageRating: number | null, reviewCount: number | null, totalSales: number | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, defaultAttributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null, variations: { nodes: Array<{ name: string | null, databaseId: number, price: string | null, regularPrice: string | null, salePrice: string | null, slug: string | null, stockQuantity: number | null, stockStatus: StockStatusEnum | null, hasAttributes: boolean | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, attributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null }> } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-          | Record<PropertyKey, never>
-        > } | null, reviews: { averageRating: number | null, edges: Array<{ rating: number | null, node: { content: string | null, id: string, date: string | null, author: { node:
-                | { name: string | null, avatar: { url: string | null } | null }
-                | { name: string | null, avatar: { url: string | null } | null }
-               } | null } }> } | null, attributes: { nodes: Array<
-          | { variation: boolean | null, name: string | null, id: string, options: Array<string | null> | null, label: string | null, scope: ProductAttributeTypesEnum, terms: { nodes: Array<
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
+    | { __typename?: 'SimpleProduct', name?: string | null, type?: ProductTypesEnum | null, databaseId: number, id: string, fullYoastHead?: string | null, slug?: string | null, sku?: string | null, description?: string | null, shortDescription?: string | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, averageRating?: number | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, reviewCount?: number | null, virtual?: boolean | null, rawDescription?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, metaData?: Array<{ __typename?: 'MetaData', id?: string | null, key: string, value?: string | null } | null> | null, related?: { __typename?: 'ProductToProductUnionConnection', nodes: Array<
+          | { __typename?: 'ExternalProduct', externalUrl?: string | null, buttonText?: string | null, onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+          | { __typename?: 'GroupProduct' }
+          | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, averageRating?: number | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, reviewCount?: number | null, virtual?: boolean | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+          | { __typename?: 'SimpleProductVariation' }
+          | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, averageRating?: number | null, reviewCount?: number | null, totalSales?: number | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, defaultAttributes?: { __typename?: 'ProductWithAttributesToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', name?: string | null, databaseId: number, price?: string | null, regularPrice?: string | null, salePrice?: string | null, slug?: string | null, stockQuantity?: number | null, stockStatus?: StockStatusEnum | null, hasAttributes?: boolean | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, attributes?: { __typename?: 'ProductVariationToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null }> } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+        > } | null, reviews?: { __typename?: 'ProductToCommentConnection', averageRating?: number | null, edges: Array<{ __typename?: 'ProductToCommentConnectionEdge', rating?: number | null, node: { __typename?: 'Comment', content?: string | null, id: string, date?: string | null, author?: { __typename?: 'CommentToCommenterConnectionEdge', node:
+                | { __typename?: 'CommentAuthor', name?: string | null, avatar?: { __typename?: 'Avatar', url?: string | null } | null }
+                | { __typename?: 'User', name?: string | null, avatar?: { __typename?: 'Avatar', url?: string | null } | null }
+               } | null } }> } | null, attributes?: { __typename?: 'ProductWithAttributesToProductAttributeConnection', nodes: Array<
+          | { __typename?: 'GlobalProductAttribute', variation?: boolean | null, name?: string | null, id: string, options?: Array<string | null> | null, label?: string | null, scope: ProductAttributeTypesEnum, terms?: { __typename?: 'GlobalProductAttributeToTermNodeConnection', nodes: Array<
+                | { __typename?: 'Category', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'GraphqlDocumentGroup', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'PaColor', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'PaRange', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'PaSize', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'PostFormat', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ProductBrand', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ProductCategory', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ProductTag', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ProductType', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ShippingClass', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'Tag', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'VisibleProduct', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
               > } | null }
-          | { variation: boolean | null, name: string | null, id: string, options: Array<string | null> | null, label: string | null, scope: ProductAttributeTypesEnum }
-        > } | null, productCategories: { nodes: Array<{ databaseId: number, slug: string | null, name: string | null, count: number | null }> } | null, terms: { nodes: Array<
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-        > } | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-    | { name: string | null, type: ProductTypesEnum | null, databaseId: number, id: string, fullYoastHead: string | null, slug: string | null, sku: string | null, description: string | null, shortDescription: string | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, weight: string | null, length: string | null, width: string | null, height: string | null, averageRating: number | null, reviewCount: number | null, totalSales: number | null, rawDescription: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, metaData: Array<{ id: string | null, key: string, value: string | null } | null> | null, related: { nodes: Array<
-          | { externalUrl: string | null, buttonText: string | null, onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-          | { name: string | null, slug: string | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, averageRating: number | null, weight: string | null, length: string | null, width: string | null, height: string | null, reviewCount: number | null, virtual: boolean | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-          | { name: string | null, slug: string | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, weight: string | null, length: string | null, width: string | null, height: string | null, averageRating: number | null, reviewCount: number | null, totalSales: number | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, defaultAttributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null, variations: { nodes: Array<{ name: string | null, databaseId: number, price: string | null, regularPrice: string | null, salePrice: string | null, slug: string | null, stockQuantity: number | null, stockStatus: StockStatusEnum | null, hasAttributes: boolean | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, attributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null }> } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-          | Record<PropertyKey, never>
-        > } | null, reviews: { averageRating: number | null, edges: Array<{ rating: number | null, node: { content: string | null, id: string, date: string | null, author: { node:
-                | { name: string | null, avatar: { url: string | null } | null }
-                | { name: string | null, avatar: { url: string | null } | null }
-               } | null } }> } | null, attributes: { nodes: Array<
-          | { variation: boolean | null, name: string | null, id: string, options: Array<string | null> | null, label: string | null, scope: ProductAttributeTypesEnum, terms: { nodes: Array<
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-                | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
+          | { __typename?: 'LocalProductAttribute', variation?: boolean | null, name?: string | null, id: string, options?: Array<string | null> | null, label?: string | null, scope: ProductAttributeTypesEnum }
+        > } | null, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', databaseId: number, slug?: string | null, name?: string | null, count?: number | null }> } | null, terms?: { __typename?: 'ProductToTermNodeConnection', nodes: Array<
+          | { __typename?: 'Category', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'GraphqlDocumentGroup', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'PaColor', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'PaRange', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'PaSize', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'PostFormat', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ProductBrand', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ProductCategory', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ProductTag', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ProductType', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ShippingClass', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'Tag', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'VisibleProduct', taxonomyName?: string | null, slug?: string | null }
+        > } | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+    | { __typename?: 'VariableProduct', name?: string | null, type?: ProductTypesEnum | null, databaseId: number, id: string, fullYoastHead?: string | null, slug?: string | null, sku?: string | null, description?: string | null, shortDescription?: string | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, averageRating?: number | null, reviewCount?: number | null, totalSales?: number | null, rawDescription?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, metaData?: Array<{ __typename?: 'MetaData', id?: string | null, key: string, value?: string | null } | null> | null, related?: { __typename?: 'ProductToProductUnionConnection', nodes: Array<
+          | { __typename?: 'ExternalProduct', externalUrl?: string | null, buttonText?: string | null, onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+          | { __typename?: 'GroupProduct' }
+          | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, averageRating?: number | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, reviewCount?: number | null, virtual?: boolean | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+          | { __typename?: 'SimpleProductVariation' }
+          | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, averageRating?: number | null, reviewCount?: number | null, totalSales?: number | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, defaultAttributes?: { __typename?: 'ProductWithAttributesToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', name?: string | null, databaseId: number, price?: string | null, regularPrice?: string | null, salePrice?: string | null, slug?: string | null, stockQuantity?: number | null, stockStatus?: StockStatusEnum | null, hasAttributes?: boolean | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, attributes?: { __typename?: 'ProductVariationToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null }> } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+        > } | null, reviews?: { __typename?: 'ProductToCommentConnection', averageRating?: number | null, edges: Array<{ __typename?: 'ProductToCommentConnectionEdge', rating?: number | null, node: { __typename?: 'Comment', content?: string | null, id: string, date?: string | null, author?: { __typename?: 'CommentToCommenterConnectionEdge', node:
+                | { __typename?: 'CommentAuthor', name?: string | null, avatar?: { __typename?: 'Avatar', url?: string | null } | null }
+                | { __typename?: 'User', name?: string | null, avatar?: { __typename?: 'Avatar', url?: string | null } | null }
+               } | null } }> } | null, attributes?: { __typename?: 'ProductWithAttributesToProductAttributeConnection', nodes: Array<
+          | { __typename?: 'GlobalProductAttribute', variation?: boolean | null, name?: string | null, id: string, options?: Array<string | null> | null, label?: string | null, scope: ProductAttributeTypesEnum, terms?: { __typename?: 'GlobalProductAttributeToTermNodeConnection', nodes: Array<
+                | { __typename?: 'Category', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'GraphqlDocumentGroup', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'PaColor', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'PaRange', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'PaSize', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'PostFormat', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ProductBrand', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ProductCategory', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ProductTag', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ProductType', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'ShippingClass', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'Tag', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+                | { __typename?: 'VisibleProduct', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
               > } | null }
-          | { variation: boolean | null, name: string | null, id: string, options: Array<string | null> | null, label: string | null, scope: ProductAttributeTypesEnum }
-        > } | null, productCategories: { nodes: Array<{ databaseId: number, slug: string | null, name: string | null, count: number | null }> } | null, terms: { nodes: Array<
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-          | { taxonomyName: string | null, slug: string | null }
-        > } | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, defaultAttributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null, variations: { nodes: Array<{ name: string | null, databaseId: number, price: string | null, regularPrice: string | null, salePrice: string | null, slug: string | null, stockQuantity: number | null, stockStatus: StockStatusEnum | null, hasAttributes: boolean | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, attributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null }> } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
+          | { __typename?: 'LocalProductAttribute', variation?: boolean | null, name?: string | null, id: string, options?: Array<string | null> | null, label?: string | null, scope: ProductAttributeTypesEnum }
+        > } | null, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', databaseId: number, slug?: string | null, name?: string | null, count?: number | null }> } | null, terms?: { __typename?: 'ProductToTermNodeConnection', nodes: Array<
+          | { __typename?: 'Category', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'GraphqlDocumentGroup', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'PaColor', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'PaRange', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'PaSize', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'PostFormat', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ProductBrand', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ProductCategory', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ProductTag', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ProductType', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'ShippingClass', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'Tag', taxonomyName?: string | null, slug?: string | null }
+          | { __typename?: 'VisibleProduct', taxonomyName?: string | null, slug?: string | null }
+        > } | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, defaultAttributes?: { __typename?: 'ProductWithAttributesToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', name?: string | null, databaseId: number, price?: string | null, regularPrice?: string | null, salePrice?: string | null, slug?: string | null, stockQuantity?: number | null, stockStatus?: StockStatusEnum | null, hasAttributes?: boolean | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, attributes?: { __typename?: 'ProductVariationToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null }> } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
    | null };
 
-type ProductWithAttributes_ExternalProduct_Fragment = { attributes: { nodes: Array<
-      | { variation: boolean | null, name: string | null, id: string, options: Array<string | null> | null, label: string | null, scope: ProductAttributeTypesEnum, terms: { nodes: Array<
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
+type ProductWithAttributes_ExternalProduct_Fragment = { __typename?: 'ExternalProduct', attributes?: { __typename?: 'ProductWithAttributesToProductAttributeConnection', nodes: Array<
+      | { __typename?: 'GlobalProductAttribute', variation?: boolean | null, name?: string | null, id: string, options?: Array<string | null> | null, label?: string | null, scope: ProductAttributeTypesEnum, terms?: { __typename?: 'GlobalProductAttributeToTermNodeConnection', nodes: Array<
+            | { __typename?: 'Category', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'GraphqlDocumentGroup', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'PaColor', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'PaRange', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'PaSize', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'PostFormat', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ProductBrand', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ProductCategory', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ProductTag', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ProductType', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ShippingClass', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'Tag', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'VisibleProduct', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
           > } | null }
-      | { variation: boolean | null, name: string | null, id: string, options: Array<string | null> | null, label: string | null, scope: ProductAttributeTypesEnum }
+      | { __typename?: 'LocalProductAttribute', variation?: boolean | null, name?: string | null, id: string, options?: Array<string | null> | null, label?: string | null, scope: ProductAttributeTypesEnum }
     > } | null };
 
-type ProductWithAttributes_GroupProduct_Fragment = { attributes: { nodes: Array<
-      | { variation: boolean | null, name: string | null, id: string, options: Array<string | null> | null, label: string | null, scope: ProductAttributeTypesEnum, terms: { nodes: Array<
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
+type ProductWithAttributes_GroupProduct_Fragment = { __typename?: 'GroupProduct', attributes?: { __typename?: 'ProductWithAttributesToProductAttributeConnection', nodes: Array<
+      | { __typename?: 'GlobalProductAttribute', variation?: boolean | null, name?: string | null, id: string, options?: Array<string | null> | null, label?: string | null, scope: ProductAttributeTypesEnum, terms?: { __typename?: 'GlobalProductAttributeToTermNodeConnection', nodes: Array<
+            | { __typename?: 'Category', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'GraphqlDocumentGroup', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'PaColor', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'PaRange', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'PaSize', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'PostFormat', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ProductBrand', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ProductCategory', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ProductTag', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ProductType', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ShippingClass', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'Tag', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'VisibleProduct', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
           > } | null }
-      | { variation: boolean | null, name: string | null, id: string, options: Array<string | null> | null, label: string | null, scope: ProductAttributeTypesEnum }
+      | { __typename?: 'LocalProductAttribute', variation?: boolean | null, name?: string | null, id: string, options?: Array<string | null> | null, label?: string | null, scope: ProductAttributeTypesEnum }
     > } | null };
 
-type ProductWithAttributes_SimpleProduct_Fragment = { attributes: { nodes: Array<
-      | { variation: boolean | null, name: string | null, id: string, options: Array<string | null> | null, label: string | null, scope: ProductAttributeTypesEnum, terms: { nodes: Array<
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
+type ProductWithAttributes_SimpleProduct_Fragment = { __typename?: 'SimpleProduct', attributes?: { __typename?: 'ProductWithAttributesToProductAttributeConnection', nodes: Array<
+      | { __typename?: 'GlobalProductAttribute', variation?: boolean | null, name?: string | null, id: string, options?: Array<string | null> | null, label?: string | null, scope: ProductAttributeTypesEnum, terms?: { __typename?: 'GlobalProductAttributeToTermNodeConnection', nodes: Array<
+            | { __typename?: 'Category', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'GraphqlDocumentGroup', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'PaColor', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'PaRange', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'PaSize', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'PostFormat', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ProductBrand', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ProductCategory', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ProductTag', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ProductType', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ShippingClass', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'Tag', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'VisibleProduct', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
           > } | null }
-      | { variation: boolean | null, name: string | null, id: string, options: Array<string | null> | null, label: string | null, scope: ProductAttributeTypesEnum }
+      | { __typename?: 'LocalProductAttribute', variation?: boolean | null, name?: string | null, id: string, options?: Array<string | null> | null, label?: string | null, scope: ProductAttributeTypesEnum }
     > } | null };
 
-type ProductWithAttributes_VariableProduct_Fragment = { attributes: { nodes: Array<
-      | { variation: boolean | null, name: string | null, id: string, options: Array<string | null> | null, label: string | null, scope: ProductAttributeTypesEnum, terms: { nodes: Array<
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-            | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
+type ProductWithAttributes_VariableProduct_Fragment = { __typename?: 'VariableProduct', attributes?: { __typename?: 'ProductWithAttributesToProductAttributeConnection', nodes: Array<
+      | { __typename?: 'GlobalProductAttribute', variation?: boolean | null, name?: string | null, id: string, options?: Array<string | null> | null, label?: string | null, scope: ProductAttributeTypesEnum, terms?: { __typename?: 'GlobalProductAttributeToTermNodeConnection', nodes: Array<
+            | { __typename?: 'Category', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'GraphqlDocumentGroup', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'PaColor', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'PaRange', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'PaSize', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'PostFormat', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ProductBrand', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ProductCategory', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ProductTag', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ProductType', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'ShippingClass', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'Tag', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+            | { __typename?: 'VisibleProduct', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
           > } | null }
-      | { variation: boolean | null, name: string | null, id: string, options: Array<string | null> | null, label: string | null, scope: ProductAttributeTypesEnum }
+      | { __typename?: 'LocalProductAttribute', variation?: boolean | null, name?: string | null, id: string, options?: Array<string | null> | null, label?: string | null, scope: ProductAttributeTypesEnum }
     > } | null };
 
 export type ProductWithAttributesFragment =
@@ -32920,23 +32338,23 @@ export type ProductWithAttributesFragment =
   | ProductWithAttributes_VariableProduct_Fragment
 ;
 
-type ProductAttribute_GlobalProductAttribute_Fragment = { variation: boolean | null, name: string | null, id: string, options: Array<string | null> | null, label: string | null, scope: ProductAttributeTypesEnum, terms: { nodes: Array<
-      | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-      | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-      | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-      | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-      | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-      | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-      | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-      | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-      | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-      | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-      | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-      | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
-      | { name: string | null, slug: string | null, taxonomyName: string | null, databaseId: number }
+type ProductAttribute_GlobalProductAttribute_Fragment = { __typename?: 'GlobalProductAttribute', variation?: boolean | null, name?: string | null, id: string, options?: Array<string | null> | null, label?: string | null, scope: ProductAttributeTypesEnum, terms?: { __typename?: 'GlobalProductAttributeToTermNodeConnection', nodes: Array<
+      | { __typename?: 'Category', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+      | { __typename?: 'GraphqlDocumentGroup', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+      | { __typename?: 'PaColor', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+      | { __typename?: 'PaRange', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+      | { __typename?: 'PaSize', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+      | { __typename?: 'PostFormat', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+      | { __typename?: 'ProductBrand', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+      | { __typename?: 'ProductCategory', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+      | { __typename?: 'ProductTag', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+      | { __typename?: 'ProductType', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+      | { __typename?: 'ShippingClass', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+      | { __typename?: 'Tag', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
+      | { __typename?: 'VisibleProduct', name?: string | null, slug?: string | null, taxonomyName?: string | null, databaseId: number }
     > } | null };
 
-type ProductAttribute_LocalProductAttribute_Fragment = { variation: boolean | null, name: string | null, id: string, options: Array<string | null> | null, label: string | null, scope: ProductAttributeTypesEnum };
+type ProductAttribute_LocalProductAttribute_Fragment = { __typename?: 'LocalProductAttribute', variation?: boolean | null, name?: string | null, id: string, options?: Array<string | null> | null, label?: string | null, scope: ProductAttributeTypesEnum };
 
 export type ProductAttributeFragment =
   | ProductAttribute_GlobalProductAttribute_Fragment
@@ -32944,81 +32362,81 @@ export type ProductAttributeFragment =
 ;
 
 export type GetProductCategoriesQueryVariables = Exact<{
-  first?: number | null | undefined;
+  first?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 
-export type GetProductCategoriesQuery = { productCategories: { nodes: Array<{ count: number | null, databaseId: number, id: string, name: string | null, slug: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null }> } | null };
+export type GetProductCategoriesQuery = { __typename?: 'RootQuery', productCategories?: { __typename?: 'RootQueryToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', count?: number | null, databaseId: number, id: string, name?: string | null, slug?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null }> } | null };
 
 export type GetProductsQueryVariables = Exact<{
-  after?: string | null | undefined;
-  slug?: Array<string | null | undefined> | string | null | undefined;
-  first?: number | null | undefined;
-  orderby?: ProductsOrderByEnum | null | undefined;
+  after?: InputMaybe<Scalars['String']['input']>;
+  slug?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>> | InputMaybe<Scalars['String']['input']>>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderby?: InputMaybe<ProductsOrderByEnum>;
 }>;
 
 
-export type GetProductsQuery = { products: { pageInfo: { hasNextPage: boolean, endCursor: string | null }, nodes: Array<
-      | { name: string | null, slug: string | null, type: ProductTypesEnum | null, databaseId: number, id: string, averageRating: number | null, reviewCount: number | null, externalUrl: string | null, buttonText: string | null, onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, terms: { nodes: Array<
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-          > } | null, productCategories: { nodes: Array<{ databaseId: number, slug: string | null, name: string | null, count: number | null }> } | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-      | { name: string | null, slug: string | null, type: ProductTypesEnum | null, databaseId: number, id: string, averageRating: number | null, reviewCount: number | null, terms: { nodes: Array<
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-          > } | null, productCategories: { nodes: Array<{ databaseId: number, slug: string | null, name: string | null, count: number | null }> } | null }
-      | { name: string | null, slug: string | null, type: ProductTypesEnum | null, databaseId: number, id: string, averageRating: number | null, reviewCount: number | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, weight: string | null, length: string | null, width: string | null, height: string | null, virtual: boolean | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, terms: { nodes: Array<
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-          > } | null, productCategories: { nodes: Array<{ databaseId: number, slug: string | null, name: string | null, count: number | null }> } | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-      | { name: string | null, slug: string | null, type: ProductTypesEnum | null, databaseId: number, id: string, averageRating: number | null, reviewCount: number | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, weight: string | null, length: string | null, width: string | null, height: string | null, totalSales: number | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, terms: { nodes: Array<
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-            | { taxonomyName: string | null, slug: string | null }
-          > } | null, productCategories: { nodes: Array<{ databaseId: number, slug: string | null, name: string | null, count: number | null }> } | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, defaultAttributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null, variations: { nodes: Array<{ name: string | null, databaseId: number, price: string | null, regularPrice: string | null, salePrice: string | null, slug: string | null, stockQuantity: number | null, stockStatus: StockStatusEnum | null, hasAttributes: boolean | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, attributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null }> } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
+export type GetProductsQuery = { __typename?: 'RootQuery', products?: { __typename?: 'RootQueryToProductConnection', pageInfo: { __typename?: 'RootQueryToProductConnectionPageInfo', hasNextPage: boolean, endCursor?: string | null }, nodes: Array<
+      | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null, type?: ProductTypesEnum | null, databaseId: number, id: string, averageRating?: number | null, reviewCount?: number | null, externalUrl?: string | null, buttonText?: string | null, onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, terms?: { __typename?: 'ProductToTermNodeConnection', nodes: Array<
+            | { __typename?: 'Category', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'GraphqlDocumentGroup', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'PaColor', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'PaRange', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'PaSize', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'PostFormat', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ProductBrand', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ProductCategory', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ProductTag', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ProductType', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ShippingClass', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'Tag', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'VisibleProduct', taxonomyName?: string | null, slug?: string | null }
+          > } | null, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', databaseId: number, slug?: string | null, name?: string | null, count?: number | null }> } | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+      | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null, type?: ProductTypesEnum | null, databaseId: number, id: string, averageRating?: number | null, reviewCount?: number | null, terms?: { __typename?: 'ProductToTermNodeConnection', nodes: Array<
+            | { __typename?: 'Category', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'GraphqlDocumentGroup', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'PaColor', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'PaRange', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'PaSize', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'PostFormat', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ProductBrand', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ProductCategory', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ProductTag', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ProductType', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ShippingClass', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'Tag', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'VisibleProduct', taxonomyName?: string | null, slug?: string | null }
+          > } | null, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', databaseId: number, slug?: string | null, name?: string | null, count?: number | null }> } | null }
+      | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, type?: ProductTypesEnum | null, databaseId: number, id: string, averageRating?: number | null, reviewCount?: number | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, virtual?: boolean | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, terms?: { __typename?: 'ProductToTermNodeConnection', nodes: Array<
+            | { __typename?: 'Category', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'GraphqlDocumentGroup', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'PaColor', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'PaRange', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'PaSize', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'PostFormat', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ProductBrand', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ProductCategory', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ProductTag', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ProductType', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ShippingClass', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'Tag', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'VisibleProduct', taxonomyName?: string | null, slug?: string | null }
+          > } | null, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', databaseId: number, slug?: string | null, name?: string | null, count?: number | null }> } | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+      | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, type?: ProductTypesEnum | null, databaseId: number, id: string, averageRating?: number | null, reviewCount?: number | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, totalSales?: number | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, terms?: { __typename?: 'ProductToTermNodeConnection', nodes: Array<
+            | { __typename?: 'Category', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'GraphqlDocumentGroup', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'PaColor', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'PaRange', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'PaSize', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'PostFormat', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ProductBrand', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ProductCategory', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ProductTag', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ProductType', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'ShippingClass', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'Tag', taxonomyName?: string | null, slug?: string | null }
+            | { __typename?: 'VisibleProduct', taxonomyName?: string | null, slug?: string | null }
+          > } | null, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', databaseId: number, slug?: string | null, name?: string | null, count?: number | null }> } | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, defaultAttributes?: { __typename?: 'ProductWithAttributesToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', name?: string | null, databaseId: number, price?: string | null, regularPrice?: string | null, salePrice?: string | null, slug?: string | null, stockQuantity?: number | null, stockStatus?: StockStatusEnum | null, hasAttributes?: boolean | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, attributes?: { __typename?: 'ProductVariationToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null }> } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
     > } | null };
 
 export type GetStatesQueryVariables = Exact<{
@@ -33026,127 +32444,128 @@ export type GetStatesQueryVariables = Exact<{
 }>;
 
 
-export type GetStatesQuery = { countryStates: Array<{ code: string, name: string } | null> | null };
+export type GetStatesQuery = { __typename?: 'RootQuery', countryStates?: Array<{ __typename?: 'CountryState', code: string, name: string } | null> | null };
 
 export type GetStockStatusQueryVariables = Exact<{
-  slug: string | number;
+  slug: Scalars['ID']['input'];
 }>;
 
 
-export type GetStockStatusQuery = { product:
-    | { stockStatus: StockStatusEnum | null }
-    | { stockStatus: StockStatusEnum | null, variations: { nodes: Array<{ stockStatus: StockStatusEnum | null }> } | null }
-    | Record<PropertyKey, never>
+export type GetStockStatusQuery = { __typename?: 'RootQuery', product?:
+    | { __typename?: 'ExternalProduct' }
+    | { __typename?: 'GroupProduct' }
+    | { __typename?: 'SimpleProduct', stockStatus?: StockStatusEnum | null }
+    | { __typename?: 'VariableProduct', stockStatus?: StockStatusEnum | null, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', stockStatus?: StockStatusEnum | null }> } | null }
    | null };
 
 export type GetStripePaymentIntentQueryVariables = Exact<{
   stripePaymentMethod: StripePaymentMethodEnum;
-  customerId?: string | null | undefined;
-  saveForFuture?: boolean | null | undefined;
+  customerId?: InputMaybe<Scalars['String']['input']>;
+  saveForFuture?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 
-export type GetStripePaymentIntentQuery = { stripePaymentIntent: { amount: number | null, clientSecret: string | null, error: string | null, id: string | null, currency: string | null, stripePaymentMethod: string | null } | null };
+export type GetStripePaymentIntentQuery = { __typename?: 'RootQuery', stripePaymentIntent?: { __typename?: 'PaymentIntent', amount?: number | null, clientSecret?: string | null, error?: string | null, id?: string | null, currency?: string | null, stripePaymentMethod?: string | null } | null };
 
 export type LoginMutationVariables = Exact<{
-  username: string;
-  password: string;
+  username: Scalars['String']['input'];
+  password: Scalars['String']['input'];
 }>;
 
 
-export type LoginMutation = { login: { authToken: string | null, authTokenExpiration: string | null, refreshToken: string | null, refreshTokenExpiration: string | null, sessionToken: string | null, user: { name: string | null, username: string | null } | null, customer: { databaseId: number | null, username: string | null, firstName: string | null, lastName: string | null } | null } | null };
+export type LoginMutation = { __typename?: 'RootMutation', login?: { __typename?: 'LoginPayload', authToken?: string | null, authTokenExpiration?: string | null, refreshToken?: string | null, refreshTokenExpiration?: string | null, sessionToken?: string | null, user?: { __typename?: 'User', name?: string | null, username?: string | null } | null, customer?: { __typename?: 'Customer', databaseId?: number | null, username?: string | null, firstName?: string | null, lastName?: string | null } | null } | null };
 
 export type LoginWithProviderMutationVariables = Exact<{
   input: LoginInput;
 }>;
 
 
-export type LoginWithProviderMutation = { login: { authToken: string | null, refreshToken: string | null, authTokenExpiration: string | null } | null };
+export type LoginWithProviderMutation = { __typename?: 'RootMutation', login?: { __typename?: 'LoginPayload', authToken?: string | null, refreshToken?: string | null, authTokenExpiration?: string | null } | null };
 
 export type LogoutMutationVariables = Exact<{ [key: string]: never; }>;
 
 
-export type LogoutMutation = { logout: { success: boolean | null } | null };
+export type LogoutMutation = { __typename?: 'RootMutation', logout?: { __typename?: 'LogoutPayload', success?: boolean | null } | null };
 
 export type RegisterCustomerMutationVariables = Exact<{
   input: RegisterCustomerInput;
 }>;
 
 
-export type RegisterCustomerMutation = { registerCustomer: { customer: { lastName: string | null, email: string | null, firstName: string | null, username: string | null, databaseId: number | null, sessionToken: string | null, isPayingCustomer: boolean | null, date: string | null, billing: { address1: string | null, address2: string | null, city: string | null, country: CountriesEnum | null, email: string | null, firstName: string | null, lastName: string | null, phone: string | null, postcode: string | null, company: string | null, state: string | null } | null, shipping: { address1: string | null, address2: string | null, city: string | null, country: CountriesEnum | null, email: string | null, firstName: string | null, lastName: string | null, phone: string | null, postcode: string | null, company: string | null, state: string | null } | null } | null } | null };
+export type RegisterCustomerMutation = { __typename?: 'RootMutation', registerCustomer?: { __typename?: 'RegisterCustomerPayload', customer?: { __typename?: 'Customer', lastName?: string | null, email?: string | null, firstName?: string | null, username?: string | null, databaseId?: number | null, sessionToken?: string | null, isPayingCustomer?: boolean | null, date?: string | null, billing?: { __typename?: 'CustomerAddress', address1?: string | null, address2?: string | null, city?: string | null, country?: CountriesEnum | null, email?: string | null, firstName?: string | null, lastName?: string | null, phone?: string | null, postcode?: string | null, company?: string | null, state?: string | null } | null, shipping?: { __typename?: 'CustomerAddress', address1?: string | null, address2?: string | null, city?: string | null, country?: CountriesEnum | null, email?: string | null, firstName?: string | null, lastName?: string | null, phone?: string | null, postcode?: string | null, company?: string | null, state?: string | null } | null } | null } | null };
 
 export type RemoveCouponsMutationVariables = Exact<{
-  codes: Array<string | null | undefined> | string;
+  codes: Array<InputMaybe<Scalars['String']['input']>> | InputMaybe<Scalars['String']['input']>;
 }>;
 
 
-export type RemoveCouponsMutation = { removeCoupons: { cart: { total: string | null, subtotal: string | null, totalTax: string | null, discountTotal: string | null, shippingTotal: string | null, needsShippingAddress: boolean | null, chosenShippingMethods: Array<string | null> | null, isEmpty: boolean | null, rawTotal: string | null, rawDiscountTotal: string | null, availableShippingMethods: Array<{ rates: Array<{ cost: string | null, id: string, label: string | null } | null> | null } | null> | null, appliedCoupons: Array<{ description: string | null, discountTax: string, discountAmount: string, code: string } | null> | null, contents: { itemCount: number | null, productCount: number | null, nodes: Array<{ quantity: number | null, key: string, product: { node:
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, externalUrl: string | null, buttonText: string | null, onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null }
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, averageRating: number | null, weight: string | null, length: string | null, width: string | null, height: string | null, reviewCount: number | null, virtual: boolean | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, weight: string | null, length: string | null, width: string | null, height: string | null, averageRating: number | null, reviewCount: number | null, totalSales: number | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, defaultAttributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null, variations: { nodes: Array<{ name: string | null, databaseId: number, price: string | null, regularPrice: string | null, salePrice: string | null, slug: string | null, stockQuantity: number | null, stockStatus: StockStatusEnum | null, hasAttributes: boolean | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, attributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null }> } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-             } | null, variation: { node: { name: string | null, slug: string | null, price: string | null, stockStatus: StockStatusEnum | null, regularPrice: string | null, salePrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null } } | null }> } | null } | null } | null };
+export type RemoveCouponsMutation = { __typename?: 'RootMutation', removeCoupons?: { __typename?: 'RemoveCouponsPayload', cart?: { __typename?: 'Cart', total?: string | null, subtotal?: string | null, totalTax?: string | null, discountTotal?: string | null, shippingTotal?: string | null, needsShippingAddress?: boolean | null, chosenShippingMethods?: Array<string | null> | null, isEmpty?: boolean | null, rawTotal?: string | null, rawDiscountTotal?: string | null, availableShippingMethods?: Array<{ __typename?: 'ShippingPackage', rates?: Array<{ __typename?: 'ShippingRate', cost?: string | null, id: string, label?: string | null } | null> | null } | null> | null, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', description?: string | null, discountTax: string, discountAmount: string, code: string } | null> | null, contents?: { __typename?: 'CartToCartItemConnection', itemCount?: number | null, productCount?: number | null, nodes: Array<{ __typename?: 'SimpleCartItem', quantity?: number | null, key: string, product?: { __typename?: 'CartItemToProductConnectionEdge', node:
+              | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, externalUrl?: string | null, buttonText?: string | null, onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+              | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null }
+              | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, averageRating?: number | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, reviewCount?: number | null, virtual?: boolean | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+              | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, averageRating?: number | null, reviewCount?: number | null, totalSales?: number | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, defaultAttributes?: { __typename?: 'ProductWithAttributesToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', name?: string | null, databaseId: number, price?: string | null, regularPrice?: string | null, salePrice?: string | null, slug?: string | null, stockQuantity?: number | null, stockStatus?: StockStatusEnum | null, hasAttributes?: boolean | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, attributes?: { __typename?: 'ProductVariationToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null }> } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+             } | null, variation?: { __typename?: 'CartItemToProductVariationConnectionEdge', node: { __typename?: 'SimpleProductVariation', name?: string | null, slug?: string | null, price?: string | null, stockStatus?: StockStatusEnum | null, regularPrice?: string | null, salePrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null } } | null }> } | null } | null } | null };
 
 export type ResetPasswordEmailMutationVariables = Exact<{
-  username: string;
+  username: Scalars['String']['input'];
 }>;
 
 
-export type ResetPasswordEmailMutation = { sendPasswordResetEmail: { success: boolean | null } | null };
+export type ResetPasswordEmailMutation = { __typename?: 'RootMutation', sendPasswordResetEmail?: { __typename?: 'SendPasswordResetEmailPayload', success?: boolean | null } | null };
 
 export type ResetPasswordKeyMutationVariables = Exact<{
-  key: string;
-  login: string;
-  password: string;
+  key: Scalars['String']['input'];
+  login: Scalars['String']['input'];
+  password: Scalars['String']['input'];
 }>;
 
 
-export type ResetPasswordKeyMutation = { resetUserPassword: { user: { id: string } | null } | null };
+export type ResetPasswordKeyMutation = { __typename?: 'RootMutation', resetUserPassword?: { __typename?: 'ResetUserPasswordPayload', user?: { __typename?: 'User', id: string } | null } | null };
 
 export type UpDateCartQuantityMutationVariables = Exact<{
-  key: string | number;
-  quantity: number;
+  key: Scalars['ID']['input'];
+  quantity: Scalars['Int']['input'];
 }>;
 
 
-export type UpDateCartQuantityMutation = { updateItemQuantities: { cart: { total: string | null, subtotal: string | null, totalTax: string | null, discountTotal: string | null, shippingTotal: string | null, needsShippingAddress: boolean | null, chosenShippingMethods: Array<string | null> | null, isEmpty: boolean | null, rawTotal: string | null, rawDiscountTotal: string | null, availableShippingMethods: Array<{ rates: Array<{ cost: string | null, id: string, label: string | null } | null> | null } | null> | null, appliedCoupons: Array<{ description: string | null, discountTax: string, discountAmount: string, code: string } | null> | null, contents: { itemCount: number | null, productCount: number | null, nodes: Array<{ quantity: number | null, key: string, product: { node:
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, externalUrl: string | null, buttonText: string | null, onSale: boolean | null, price: string | null, regularPrice: string | null, salePrice: string | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null }
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, averageRating: number | null, weight: string | null, length: string | null, width: string | null, height: string | null, reviewCount: number | null, virtual: boolean | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-              | { name: string | null, slug: string | null, sku: string | null, databaseId: number, type: ProductTypesEnum | null, price: string | null, date: string | null, regularPrice: string | null, salePrice: string | null, stockStatus: StockStatusEnum | null, stockQuantity: number | null, lowStockAmount: number | null, onSale: boolean | null, weight: string | null, length: string | null, width: string | null, height: string | null, averageRating: number | null, reviewCount: number | null, totalSales: number | null, rawPrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, defaultAttributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null, variations: { nodes: Array<{ name: string | null, databaseId: number, price: string | null, regularPrice: string | null, salePrice: string | null, slug: string | null, stockQuantity: number | null, stockStatus: StockStatusEnum | null, hasAttributes: boolean | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null, databaseId: number, cartSourceUrl: string | null, productCardSourceUrl: string | null } | null, attributes: { nodes: Array<{ name: string | null, attributeId: number | null, value: string | null, label: string | null }> } | null }> } | null, galleryImages: { nodes: Array<{ databaseId: number, sourceUrl: string | null, altText: string | null, title: string | null }> } | null }
-             } | null, variation: { node: { name: string | null, slug: string | null, price: string | null, stockStatus: StockStatusEnum | null, regularPrice: string | null, salePrice: string | null, rawRegularPrice: string | null, rawSalePrice: string | null, image: { sourceUrl: string | null, altText: string | null, title: string | null } | null } } | null }> } | null } | null } | null };
+export type UpDateCartQuantityMutation = { __typename?: 'RootMutation', updateItemQuantities?: { __typename?: 'UpdateItemQuantitiesPayload', cart?: { __typename?: 'Cart', total?: string | null, subtotal?: string | null, totalTax?: string | null, discountTotal?: string | null, shippingTotal?: string | null, needsShippingAddress?: boolean | null, chosenShippingMethods?: Array<string | null> | null, isEmpty?: boolean | null, rawTotal?: string | null, rawDiscountTotal?: string | null, availableShippingMethods?: Array<{ __typename?: 'ShippingPackage', rates?: Array<{ __typename?: 'ShippingRate', cost?: string | null, id: string, label?: string | null } | null> | null } | null> | null, appliedCoupons?: Array<{ __typename?: 'AppliedCoupon', description?: string | null, discountTax: string, discountAmount: string, code: string } | null> | null, contents?: { __typename?: 'CartToCartItemConnection', itemCount?: number | null, productCount?: number | null, nodes: Array<{ __typename?: 'SimpleCartItem', quantity?: number | null, key: string, product?: { __typename?: 'CartItemToProductConnectionEdge', node:
+              | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, externalUrl?: string | null, buttonText?: string | null, onSale?: boolean | null, price?: string | null, regularPrice?: string | null, salePrice?: string | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+              | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null }
+              | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, averageRating?: number | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, reviewCount?: number | null, virtual?: boolean | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+              | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null, sku?: string | null, databaseId: number, type?: ProductTypesEnum | null, price?: string | null, date?: string | null, regularPrice?: string | null, salePrice?: string | null, stockStatus?: StockStatusEnum | null, stockQuantity?: number | null, lowStockAmount?: number | null, onSale?: boolean | null, weight?: string | null, length?: string | null, width?: string | null, height?: string | null, averageRating?: number | null, reviewCount?: number | null, totalSales?: number | null, rawPrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, defaultAttributes?: { __typename?: 'ProductWithAttributesToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', name?: string | null, databaseId: number, price?: string | null, regularPrice?: string | null, salePrice?: string | null, slug?: string | null, stockQuantity?: number | null, stockStatus?: StockStatusEnum | null, hasAttributes?: boolean | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null, databaseId: number, cartSourceUrl?: string | null, productCardSourceUrl?: string | null } | null, attributes?: { __typename?: 'ProductVariationToVariationAttributeConnection', nodes: Array<{ __typename?: 'VariationAttribute', name?: string | null, attributeId?: number | null, value?: string | null, label?: string | null }> } | null }> } | null, galleryImages?: { __typename?: 'ProductToMediaItemConnection', nodes: Array<{ __typename?: 'MediaItem', databaseId: number, sourceUrl?: string | null, altText?: string | null, title?: string | null }> } | null }
+             } | null, variation?: { __typename?: 'CartItemToProductVariationConnectionEdge', node: { __typename?: 'SimpleProductVariation', name?: string | null, slug?: string | null, price?: string | null, stockStatus?: StockStatusEnum | null, regularPrice?: string | null, salePrice?: string | null, rawRegularPrice?: string | null, rawSalePrice?: string | null, image?: { __typename?: 'MediaItem', sourceUrl?: string | null, altText?: string | null, title?: string | null } | null } } | null }> } | null } | null } | null };
 
 export type UpdateCustomerMutationVariables = Exact<{
   input: UpdateCustomerInput;
 }>;
 
 
-export type UpdateCustomerMutation = { updateCustomer: { customer: { downloadableItems: { nodes: Array<{ id: string, name: string | null, url: string | null, accessExpires: string | null, downloadsRemaining: number | null, product:
-            | { name: string | null, slug: string | null }
-            | { name: string | null, slug: string | null }
-            | { name: string | null, slug: string | null }
-            | { name: string | null, slug: string | null }
-            | { name: string | null, slug: string | null }
+export type UpdateCustomerMutation = { __typename?: 'RootMutation', updateCustomer?: { __typename?: 'UpdateCustomerPayload', customer?: { __typename?: 'Customer', downloadableItems?: { __typename?: 'CustomerToDownloadableItemConnection', nodes: Array<{ __typename?: 'DownloadableItem', id: string, name?: string | null, url?: string | null, accessExpires?: string | null, downloadsRemaining?: number | null, product?:
+            | { __typename?: 'ExternalProduct', name?: string | null, slug?: string | null }
+            | { __typename?: 'GroupProduct', name?: string | null, slug?: string | null }
+            | { __typename?: 'SimpleProduct', name?: string | null, slug?: string | null }
+            | { __typename?: 'SimpleProductVariation', name?: string | null, slug?: string | null }
+            | { __typename?: 'VariableProduct', name?: string | null, slug?: string | null }
            | null }> } | null } | null } | null };
 
 export type UpdatePasswordMutationVariables = Exact<{
-  id: string | number;
-  password: string;
+  id: Scalars['ID']['input'];
+  password: Scalars['String']['input'];
 }>;
 
 
-export type UpdatePasswordMutation = { updateUser: { user: { id: string } | null } | null };
+export type UpdatePasswordMutation = { __typename?: 'RootMutation', updateUser?: { __typename?: 'UpdateUserPayload', user?: { __typename?: 'User', id: string } | null } | null };
 
 export type WriteReviewMutationVariables = Exact<{
-  author: string;
-  commentOn: number;
-  content: string;
-  rating: number;
-  authorEmail: string;
+  author: Scalars['String']['input'];
+  commentOn: Scalars['Int']['input'];
+  content: Scalars['String']['input'];
+  rating: Scalars['Int']['input'];
+  authorEmail: Scalars['String']['input'];
 }>;
 
 
-export type WriteReviewMutation = { writeReview: { rating: number | null, review: { id: string } | null } | null };
+export type WriteReviewMutation = { __typename?: 'RootMutation', writeReview?: { __typename?: 'WriteReviewPayload', rating?: number | null, review?: { __typename?: 'Comment', id: string } | null } | null };
 
 export const ImageFragmentDoc = gql`
     fragment Image on MediaItem {

--- a/woonuxt_base/app/gql/default.ts
+++ b/woonuxt_base/app/gql/default.ts
@@ -1241,6 +1241,8 @@ export type CheckoutInput = {
   billing?: InputMaybe<CustomerAddressInput>;
   /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
+  /** Source of the order. Useful when WooCommerce is driven from multiple sources. Defaults to "checkout". */
+  createdVia?: InputMaybe<Scalars['String']['input']>;
   /** Order customer note */
   customerNote?: InputMaybe<Scalars['String']['input']>;
   /** Fees to add to the order. */
@@ -3533,6 +3535,8 @@ export type CreateOrderInput = {
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** Coupons codes to be applied to order */
   coupons?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  /** Source of the order. Useful when WooCommerce is driven from multiple sources. Defaults to "graphql-api". */
+  createdVia?: InputMaybe<Scalars['String']['input']>;
   /** Currency the order was created with, in ISO format. */
   currency?: InputMaybe<CurrencyEnum>;
   /** Order customer ID */
@@ -15333,6 +15337,8 @@ export type ProductBrand = DatabaseIdentifier & HierarchicalNode & HierarchicalT
   enqueuedStylesheets?: Maybe<TermNodeToEnqueuedStylesheetConnection>;
   /** The globally unique ID for the object */
   id: Scalars['ID']['output'];
+  /** Product brand image */
+  image?: Maybe<MediaItem>;
   /** Whether the node is a Comment */
   isComment: Scalars['Boolean']['output'];
   /** Whether the node is a Content Node */
@@ -28453,6 +28459,8 @@ export type UpdateOrderInput = {
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   /** Coupons codes to be applied to order */
   coupons?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  /** Source of the order. Useful when WooCommerce is driven from multiple sources. Defaults to "graphql-api". */
+  createdVia?: InputMaybe<Scalars['String']['input']>;
   /** Currency the order was created with, in ISO format. */
   currency?: InputMaybe<CurrencyEnum>;
   /** Database ID or global ID of the customer for the order */
@@ -32332,6 +32340,7 @@ export type CheckoutMutationVariables = Exact<{
   transactionId?: string | null | undefined;
   isPaid?: boolean | null | undefined;
   shippingMethod?: Array<string | null | undefined> | string | null | undefined;
+  createdVia?: string | null | undefined;
 }>;
 
 
@@ -33711,9 +33720,9 @@ export const ChangeShippingMethodDocument = gql`
 }
     ${CartFragmentDoc}`;
 export const CheckoutDocument = gql`
-    mutation Checkout($billing: CustomerAddressInput = {}, $metaData: [MetaDataInput] = [], $paymentMethod: String = "stripe", $shipping: CustomerAddressInput = {}, $customerNote: String = "", $shipToDifferentAddress: Boolean = false, $account: CreateAccountInput = {username: "", password: ""}, $transactionId: String = "", $isPaid: Boolean = false, $shippingMethod: [String] = []) {
+    mutation Checkout($billing: CustomerAddressInput = {}, $metaData: [MetaDataInput] = [], $paymentMethod: String = "stripe", $shipping: CustomerAddressInput = {}, $customerNote: String = "", $shipToDifferentAddress: Boolean = false, $account: CreateAccountInput = {username: "", password: ""}, $transactionId: String = "", $isPaid: Boolean = false, $shippingMethod: [String] = [], $createdVia: String = "WooNuxt") {
   checkout(
-    input: {paymentMethod: $paymentMethod, billing: $billing, metaData: $metaData, shipping: $shipping, shippingMethod: $shippingMethod, customerNote: $customerNote, shipToDifferentAddress: $shipToDifferentAddress, account: $account, transactionId: $transactionId, isPaid: $isPaid}
+    input: {paymentMethod: $paymentMethod, billing: $billing, metaData: $metaData, shipping: $shipping, shippingMethod: $shippingMethod, customerNote: $customerNote, shipToDifferentAddress: $shipToDifferentAddress, account: $account, transactionId: $transactionId, isPaid: $isPaid, createdVia: $createdVia}
   ) {
     result
     redirect

--- a/woonuxt_base/app/pages/product/[slug].vue
+++ b/woonuxt_base/app/pages/product/[slug].vue
@@ -241,10 +241,11 @@ const mergeLiveStockStatus = (payload: ProductDetail): void => {
       variations: product.value.variations
         ? {
             ...product.value.variations,
-            nodes: product.value.variations.nodes?.map((node, index) => ({
-              ...node,
-              stockStatus: payload.variations?.nodes?.[index]?.stockStatus || node.stockStatus,
-            })),
+            nodes:
+              product.value.variations.nodes?.map((node, index) => ({
+                ...node,
+                stockStatus: payload.variations?.nodes?.[index]?.stockStatus || node.stockStatus,
+              })) ?? [],
           }
         : undefined,
     };

--- a/woonuxt_base/app/queries/checkout.gql
+++ b/woonuxt_base/app/queries/checkout.gql
@@ -9,6 +9,7 @@ mutation Checkout(
   $transactionId: String = ""
   $isPaid: Boolean = false
   $shippingMethod: [String] = []
+  $createdVia: String = "WooNuxt"
 ) {
   checkout(
     input: {
@@ -22,6 +23,7 @@ mutation Checkout(
       account: $account
       transactionId: $transactionId
       isPaid: $isPaid
+      createdVia: $createdVia
     }
   ) {
     result

--- a/woonuxt_base/nuxt.config.ts
+++ b/woonuxt_base/nuxt.config.ts
@@ -1,5 +1,6 @@
 import { createResolver } from '@nuxt/kit';
 import { defineNuxtConfig } from 'nuxt/config';
+import tailwindcss from '@tailwindcss/vite';
 
 const { resolve } = createResolver(import.meta.url);
 
@@ -20,6 +21,7 @@ export default defineNuxtConfig({
   },
 
   vite: {
+    plugins: [tailwindcss()],
     optimizeDeps: {
       include: [
         '@stripe/stripe-js/pure',
@@ -65,12 +67,6 @@ export default defineNuxtConfig({
     '@nuxt/eslint',
     '@vite-pwa/nuxt',
   ],
-
-  postcss: {
-    plugins: {
-      '@tailwindcss/postcss': {},
-    },
-  },
 
   css: [resolve('./app/assets/css/main.css')],
 

--- a/woonuxt_base/package.json
+++ b/woonuxt_base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woonuxt",
-  "version": "4.26.2",
+  "version": "4.26.3",
   "main": "./nuxt.config.ts",
   "type": "module",
   "imports": {


### PR DESCRIPTION
This pull request updates dependencies, improves type safety, and adds new features to the checkout and order flows. Notably, it introduces a `createdVia` field to track the source of orders, enhances the `ProductBrand` type, and updates several package versions for compatibility and security.

### Feature additions and improvements:

* Added a `createdVia` field to `CheckoutInput`, `CreateOrderInput`, and `UpdateOrderInput`, as well as the `Checkout` mutation and related GraphQL query/variable types, allowing the source of the order to be specified (defaults to "WooNuxt" or "graphql-api"). [[1]](diffhunk://#diff-395e540ebbfb9f8cb6f5bd3b8f540d8d573e6e97cc3556443d05c15867e16913R1244-R1245) [[2]](diffhunk://#diff-395e540ebbfb9f8cb6f5bd3b8f540d8d573e6e97cc3556443d05c15867e16913R3538-R3539) [[3]](diffhunk://#diff-395e540ebbfb9f8cb6f5bd3b8f540d8d573e6e97cc3556443d05c15867e16913R28462-R28463) [[4]](diffhunk://#diff-395e540ebbfb9f8cb6f5bd3b8f540d8d573e6e97cc3556443d05c15867e16913R32343) [[5]](diffhunk://#diff-395e540ebbfb9f8cb6f5bd3b8f540d8d573e6e97cc3556443d05c15867e16913L33714-R33725) [[6]](diffhunk://#diff-becc7e1684224109bc9fd06f1b2008db82f32cef891a8aa3b384a02f08c2fb4cR12) [[7]](diffhunk://#diff-becc7e1684224109bc9fd06f1b2008db82f32cef891a8aa3b384a02f08c2fb4cR26)
* Added an `image` field to the `ProductBrand` GraphQL type to support product brand images.

### Dependency and compatibility updates:

* Updated several dependencies in `package.json`, including `@stripe/stripe-js`, `@tailwindcss/postcss`, `tailwindcss`, `@graphql-codegen/typescript-operations`, and `nuxt` to their latest versions for improved compatibility and security. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L22-R36) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L45-R45)
* Updated `woonuxt_base` package version to `4.26.3`.
* Updated required `WooGraphQL` version in `README.md` to `1.0.3`.

### Type safety and code improvements:

* Improved type safety in `SEOHead.vue` by casting `meta`, `link`, and `script` properties to the correct types and importing the appropriate type definitions. [[1]](diffhunk://#diff-5fdcfd08bde950ba4206f0143b47b4f0cafedf3a8d0ba4bc9aad3aa97f744091R2) [[2]](diffhunk://#diff-5fdcfd08bde950ba4206f0143b47b4f0cafedf3a8d0ba4bc9aad3aa97f744091L15-R18)
* Changed the Tailwind CSS import path in `main.css` to directly reference the installed package, improving reliability.