### PR TITLE
chore: update dependencies for @stripe/stripe-js, reka-ui, @graphql-c…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,33 +7,33 @@
       "name": "woonuxt",
       "hasInstallScript": true,
       "dependencies": {
-        "@stripe/stripe-js": "^9.13.0",
+        "@stripe/stripe-js": "^9.14.0",
         "@tailwindcss/vite": "^4.3.3",
         "@vueuse/core": "^14.4.0",
         "graphql": "^16.14.2",
         "graphql-request": "^7.4.0",
-        "reka-ui": "^2.10.3",
+        "reka-ui": "^2.10.4",
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.3"
       },
       "devDependencies": {
         "@graphql-codegen/add": "^7.1.0",
-        "@graphql-codegen/cli": "^7.2.0",
+        "@graphql-codegen/cli": "^7.3.1",
         "@graphql-codegen/typescript": "5.0.10",
         "@graphql-codegen/typescript-graphql-request": "^7.1.0",
         "@graphql-codegen/typescript-operations": "5.1.0",
         "@iconify-json/ion": "^1.2.7",
         "@nuxt/eslint": "^1.17.0",
-        "@nuxt/icon": "^2.5.0",
+        "@nuxt/icon": "^2.5.1",
         "@nuxt/image": "2.1.0",
         "@nuxtjs/i18n": "^10.6.0",
         "@tailwindcss/typography": "^0.5.20",
         "@vite-pwa/nuxt": "^1.1.1",
-        "eslint": "^10.8.1",
+        "eslint": "^10.9.1",
         "nuxt": "^4.5.2",
         "prettier": "^3.9.6",
         "typescript": "^6.0.3",
-        "vue-tsc": "^3.3.10"
+        "vue-tsc": "^3.3.11"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -2549,18 +2549,18 @@
       }
     },
     "node_modules/@graphql-codegen/cli": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-7.2.0.tgz",
-      "integrity": "sha512-JPJw2vquEIpO3b8XJyxFVTrYi6WRn/OKu/SlzQA+IwAVT7GZPeG+AHmfRXAvpVMj31899nTpQYEQGUxx3ZqubQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-7.3.1.tgz",
+      "integrity": "sha512-xDEI/Jpw2bmLyHJ3KDO6UavOKxujSO08p8Bz31NwRNhvKnVpy2N5tiYZhnhIBCcCqUb7PfTt11dr5EWGZGgB4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.18.13",
         "@babel/template": "^7.18.10",
         "@babel/types": "^7.18.13",
-        "@graphql-codegen/client-preset": "^6.1.0",
+        "@graphql-codegen/client-preset": "^6.1.3",
         "@graphql-codegen/core": "^6.2.0",
-        "@graphql-codegen/plugin-helpers": "^7.1.0",
+        "@graphql-codegen/plugin-helpers": "^7.2.1",
         "@graphql-tools/apollo-engine-loader": "^8.0.28",
         "@graphql-tools/code-file-loader": "^8.1.28",
         "@graphql-tools/git-loader": "^8.0.32",
@@ -2612,9 +2612,9 @@
       }
     },
     "node_modules/@graphql-codegen/client-preset": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/client-preset/-/client-preset-6.1.0.tgz",
-      "integrity": "sha512-mGmBuwrOU5oRoaWFodx8g9xu1jecYIiydqvk88QsAIsyMcZwuoybs1lyne85TovpBHjH5CC2wnZGsbDQfcgOCQ==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/client-preset/-/client-preset-6.1.3.tgz",
+      "integrity": "sha512-bIuJiirdwzx784bnqZsoC+wEzCyhr0T+tbVhwuZRudyZXPeLm+7/tn/FTAMqZhDGgSr6hVnpcU41abdBNn2zag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2625,8 +2625,8 @@
         "@graphql-codegen/plugin-helpers": "^7.1.0",
         "@graphql-codegen/typed-document-node": "^7.1.0",
         "@graphql-codegen/typescript": "^6.1.0",
-        "@graphql-codegen/typescript-operations": "^6.1.0",
-        "@graphql-codegen/visitor-plugin-common": "^7.2.0",
+        "@graphql-codegen/typescript-operations": "^6.1.6",
+        "@graphql-codegen/visitor-plugin-common": "^7.2.5",
         "@graphql-tools/documents": "^1.0.0",
         "@graphql-tools/utils": "^11.2.0",
         "@graphql-typed-document-node/core": "3.2.0",
@@ -2684,15 +2684,15 @@
       }
     },
     "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/typescript-operations": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-6.1.1.tgz",
-      "integrity": "sha512-mCcG5Sx9kIcWsX/HCgvoqDVN4IqC7ma++BWIhVotf2k8mx15/AHgraUWQvKkPKljUKRPzSLbsj3k3rdnAhWquQ==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-6.1.6.tgz",
+      "integrity": "sha512-qsYRkK27YbSL2doifPvldVwdwHRQtpsxXJINs22wQWGksC1Mrgn9YNaAGUZ2so46U20TKTm4SBoiNXRJE3esqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^7.1.0",
         "@graphql-codegen/schema-ast": "^6.1.0",
-        "@graphql-codegen/visitor-plugin-common": "^7.2.1",
+        "@graphql-codegen/visitor-plugin-common": "^7.2.5",
         "auto-bind": "^5.0.0",
         "tslib": "^2.8.0"
       },
@@ -2749,9 +2749,9 @@
       }
     },
     "node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.1.0.tgz",
-      "integrity": "sha512-ieJH7kZ5oSZKBPJs7CvHMrFY/CLYLklqv74ir93qMwRna6geZsbIMoJzTDBXohxcQTITiProiYSGrEtZjIpYGg==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.2.1.tgz",
+      "integrity": "sha512-Jw2HPaioMEa4DKG7sgqzL1uWQiIWQu774FwKXx4p83/y3o5GgnRMRdTFtuQQ7Tq6PYyrI5ZITi1jAxeX/Vh2Uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3308,9 +3308,9 @@
       }
     },
     "node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.2.1.tgz",
-      "integrity": "sha512-OfTs7yvdbG3LaDJ158vtlglF0QzRN6b/t2Xi02DqBDfJqUorUM72uzuG9BpeALTPNTxFU7aaauS57uTc5oJjsw==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.2.5.tgz",
+      "integrity": "sha512-hqOemBp0Ue+WSmk8EDcKP+lghuLC2zsI+jHzSUuoffTZnEN2qZH4VP2C9c1fVd2yy6v+YQiiObOarTMaqF4q9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3906,9 +3906,9 @@
       }
     },
     "node_modules/@iconify/collections": {
-      "version": "1.0.723",
-      "resolved": "https://registry.npmjs.org/@iconify/collections/-/collections-1.0.723.tgz",
-      "integrity": "sha512-h9/C2f+OC/iYFwCuqPh8nFAdAbRyV0TwNUGEA2L3VI4hC89YUa6LOBMr/6LUAgcd3wMPXPnnt0Y6Ecgxqb/rIQ==",
+      "version": "1.0.728",
+      "resolved": "https://registry.npmjs.org/@iconify/collections/-/collections-1.0.728.tgz",
+      "integrity": "sha512-vzRn5TOgHv5cp/gpXQ42FfywPxa2htotIypQfSVt7GXiMHeYzmawMDii2IYHFYNmpWyamuMzvMci/JlNz9epkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6005,36 +6005,12 @@
         }
       }
     },
-    "node_modules/@nuxt/cli/node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@nuxt/cli/node_modules/citty": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
       "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@nuxt/cli/node_modules/commander": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=22.12.0"
-      }
     },
     "node_modules/@nuxt/cli/node_modules/semver": {
       "version": "7.8.5",
@@ -6309,26 +6285,40 @@
       }
     },
     "node_modules/@nuxt/icon": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/icon/-/icon-2.5.0.tgz",
-      "integrity": "sha512-EBczSfd3QmAD7GoSmJ5jCPvQ5zzNaPPuWPU9DSMcBuBM10A3JIvjaMLEOEniHQRz4iVPb05cJRO/JdC60oiiwg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/icon/-/icon-2.5.1.tgz",
+      "integrity": "sha512-zBP72Po7BS+tXzoeDRA/Y9TTY77OIcNCyzfgXsOmep7zZShTEoe4p1WZBXce/9oJDK3YXmbYC3ILQ7XvqM4/XA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@iconify/collections": "^1.0.721",
+        "@iconify/collections": "^1.0.727",
         "@iconify/types": "^2.0.0",
         "@iconify/utils": "^3.1.4",
         "@iconify/vue": "^5.0.1",
-        "@nuxt/devtools-kit": "^3.4.1",
+        "@nuxt/devtools-kit": "^3.4.2",
         "@nuxt/kit": "^4.5.2",
         "consola": "^3.4.2",
         "local-pkg": "^1.2.1",
         "mlly": "^1.8.2",
-        "ohash": "^2.0.11",
+        "ohash": "^2.0.12",
         "picomatch": "^4.0.5",
         "std-env": "^4.2.0",
         "tinyglobby": "^0.2.17",
         "ufo": "^1.6.4"
+      }
+    },
+    "node_modules/@nuxt/icon/node_modules/@nuxt/devtools-kit": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-3.4.2.tgz",
+      "integrity": "sha512-TPPbmH9xrExagYxfCe6JgtbHmgchfgDdA656Yws18rn8I/oCvB+gcw3kTWBBp2sC9ipZPXsgbsW/yZnVnGNBiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/kit": "^4.5.1",
+        "execa": "^8.0.1"
+      },
+      "peerDependencies": {
+        "vite": ">=6.0"
       }
     },
     "node_modules/@nuxt/image": {
@@ -8214,9 +8204,9 @@
       "license": "MIT"
     },
     "node_modules/@stripe/stripe-js": {
-      "version": "9.13.0",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.13.0.tgz",
-      "integrity": "sha512-/0c72BUgzzVkVTlsw5uBn8x3waTdVJ/PZGfQ6jY1eu6K7olUPf4d9lgDPA9/0sIdsR8j7o3QIG8fOCO6ItcL7A==",
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.14.0.tgz",
+      "integrity": "sha512-eCeVT2ee5YWyzz+m/cGwuatcPobe0MxzUGJtat8vUuZo4vNg1bzhoImKaTG2uB1ytIO03MrYAP4d6PTiGl+IZQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12.16"
@@ -9796,9 +9786,9 @@
       "license": "MIT"
     },
     "node_modules/@vue/language-core": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.10.tgz",
-      "integrity": "sha512-CR7ByBbgPHqhxrioKPOcZBqttaozzLNwtkCzXQ+uF8gLPHnUe03srPnGpdtHD3zp+bq5iyVkZ1WNx7W564RPwg==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.11.tgz",
+      "integrity": "sha512-QJmpliwAVpC/OxubIByPAhNzsQPRc8/gxlN2qnVzVfIMjMDz/9RnXRFoetjz5yEgXVXyp4LqhXq3V53PjmNzFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12601,9 +12591,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
-      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
+      "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -17629,9 +17619,9 @@
       }
     },
     "node_modules/ohash": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
+      "integrity": "sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==",
       "license": "MIT"
     },
     "node_modules/on-change": {
@@ -19172,9 +19162,9 @@
       }
     },
     "node_modules/reka-ui": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/reka-ui/-/reka-ui-2.10.3.tgz",
-      "integrity": "sha512-nJGZbwcha8AcP2wbnjodfzsciTKBqp1mIzepC9Pi2xDI/YK3++ej3vpJOSPyxqrkq1Oorj4K+BdJkbVCV6x6ag==",
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/reka-ui/-/reka-ui-2.10.4.tgz",
+      "integrity": "sha512-kbS5GAbkHkYj0EVKAg5ZPEPndhBjeUFSa1Aq5m5ftQwyHnB1v5tw8X6fcwfKH/ry3StPXblMWM1DW82MVS71cw==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.6.13",
@@ -22667,14 +22657,14 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.10.tgz",
-      "integrity": "sha512-YaDVxcW+CGtaOt3pZahMG5jYPx0hsUTxyEoPOTSMebcGUXP9lIBabQ14vfKMORb2CqqK5CxsNo/d1d+4IQwiKg==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.11.tgz",
+      "integrity": "sha512-gOb0B9rtU2+f1dszwPqSH5kAieIF9ReeLhD3kSRNHv5WZZUQz/JdVXW0RTdqhNTMlQkqKzrTTviqKr/4FYZraQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "2.4.28",
-        "@vue/language-core": "3.3.10"
+        "@vue/language-core": "3.3.11"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"

--- a/package.json
+++ b/package.json
@@ -22,32 +22,32 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "@stripe/stripe-js": "^9.13.0",
+    "@stripe/stripe-js": "^9.14.0",
     "@tailwindcss/vite": "^4.3.3",
     "@vueuse/core": "^14.4.0",
     "graphql": "^16.14.2",
     "graphql-request": "^7.4.0",
-    "reka-ui": "^2.10.3",
+    "reka-ui": "^2.10.4",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.3"
   },
   "devDependencies": {
     "@graphql-codegen/add": "^7.1.0",
-    "@graphql-codegen/cli": "^7.2.0",
+    "@graphql-codegen/cli": "^7.3.1",
     "@graphql-codegen/typescript": "5.0.10",
     "@graphql-codegen/typescript-graphql-request": "^7.1.0",
     "@graphql-codegen/typescript-operations": "5.1.0",
     "@iconify-json/ion": "^1.2.7",
     "@nuxt/eslint": "^1.17.0",
-    "@nuxt/icon": "^2.5.0",
+    "@nuxt/icon": "^2.5.1",
     "@nuxt/image": "2.1.0",
     "@nuxtjs/i18n": "^10.6.0",
     "@tailwindcss/typography": "^0.5.20",
     "@vite-pwa/nuxt": "^1.1.1",
-    "eslint": "^10.8.1",
+    "eslint": "^10.9.1",
     "nuxt": "^4.5.2",
     "prettier": "^3.9.6",
     "typescript": "^6.0.3",
-    "vue-tsc": "^3.3.10"
+    "vue-tsc": "^3.3.11"
   }
 }


### PR DESCRIPTION
This pull request updates several dependencies and devDependencies in the `package.json` file to their latest patch or minor versions. These changes help ensure the project benefits from the latest features, bug fixes, and security improvements.

Dependency updates:

* Upgraded `@stripe/stripe-js` from `^9.13.0` to `^9.14.0` to include the latest improvements and fixes.
* Updated `reka-ui` from `^2.10.3` to `^2.10.4` for minor enhancements and bug fixes.

DevDependency updates:

* Bumped `@graphql-codegen/cli` from `^7.2.0` to `^7.3.1` for improved code generation tooling.
* Upgraded `@nuxt/icon` from `^2.5.0` to `^2.5.1` for the latest icon features and fixes.
* Updated `eslint` from `^10.8.1` to `^10.9.1` for improved linting and bug fixes.
* Bumped `vue-tsc` from `^3.3.10` to `^3.3.11` for better TypeScript type…odegen/cli, @nuxt/icon, eslint, and vue-tsc